### PR TITLE
fix: restore guest mode access on landing and auth pages

### DIFF
--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -215,6 +215,19 @@ const Auth: React.FC = () => {
               {mode === 'login' ? "Pas de compte ? Inscris-toi !" : "Déjà un compte ? Connecte-toi !"}
             </button>
           </p>
+
+          <div className="flex items-center gap-3 my-4">
+            <div className="flex-1 h-px bg-border" />
+            <span className="font-pixel text-[7px] text-muted-foreground">OU</span>
+            <div className="flex-1 h-px bg-border" />
+          </div>
+
+          <button
+            onClick={() => navigate('/game')}
+            className="w-full font-pixel text-[7px] text-muted-foreground hover:text-foreground transition-colors py-2"
+          >
+            CONTINUER EN INVITÉ (sans sauvegarde cloud)
+          </button>
         </div>
       </motion.div>
     </div>

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -365,6 +365,10 @@ const Landing: React.FC = () => {
                   className="pixel-btn pixel-btn-secondary font-pixel text-[10px] sm:text-xs px-6 py-4 flex items-center gap-2">
                   <Shield size={16} /> SE CONNECTER
                 </motion.button>
+                <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} onClick={() => navigate('/game')}
+                  className="pixel-btn font-pixel text-[10px] sm:text-xs px-6 py-4 flex items-center gap-2 border-muted-foreground/40 text-muted-foreground hover:text-foreground">
+                  JOUER EN INVITÉ
+                </motion.button>
               </>
             )}
           </div>
@@ -556,10 +560,18 @@ const Landing: React.FC = () => {
           <p className="text-sm text-muted-foreground mb-8">
             Crée ton compte gratuitement et commence à collectionner des héros dès maintenant !
           </p>
-          <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} onClick={() => navigate(user ? '/game' : '/auth')}
-            className="pixel-btn pixel-btn-gold font-pixel text-xs px-10 py-4 flex items-center gap-2 mx-auto">
-            <Zap size={18} /> {user ? 'JOUER' : 'CRÉER MON COMPTE'}
-          </motion.button>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} onClick={() => navigate(user ? '/game' : '/auth')}
+              className="pixel-btn pixel-btn-gold font-pixel text-xs px-10 py-4 flex items-center gap-2 mx-auto">
+              <Zap size={18} /> {user ? 'JOUER' : 'CRÉER MON COMPTE'}
+            </motion.button>
+            {!user && (
+              <motion.button whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }} onClick={() => navigate('/game')}
+                className="pixel-btn font-pixel text-[10px] px-8 py-4 flex items-center gap-2 mx-auto border-muted-foreground/40 text-muted-foreground hover:text-foreground">
+                JOUER EN INVITÉ
+              </motion.button>
+            )}
+          </div>
         </motion.div>
       </section>
 


### PR DESCRIPTION
The guest mode was no longer accessible because no button existed to
navigate to /game without authenticating. Added a "JOUER EN INVITÉ"
button on the hero section and CTA of the landing page, and a
"CONTINUER EN INVITÉ" link on the auth page. The game already supports
unauthenticated play via localStorage — this just re-exposes the entry
points.

Fixes #2

https://claude.ai/code/session_014tiekSz9pyYrrLACzboi4j