### PR TITLE
feat: add 'Tout fusionner' button and auto-merge option (Closes #25)

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,6 +22,7 @@ import DailyQuests from '@/components/DailyQuests';
 import PixelIcon from '@/components/PixelIcon';
 import { Home, Users, Sparkles, Swords, Map, Trophy, Coins, Star, ChevronLeft, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Bomb, Lock as LockIcon, Volume2, VolumeX } from 'lucide-react';
 import { SFX, isMuted, setMuted } from '@/game/sfx';
+import { toast } from '@/hooks/use-toast';
 
 type Screen = 'hub' | 'treasure-hunt' | 'heroes' | 'summon' | 'story' | 'story-battle';
 
@@ -51,6 +52,8 @@ const Index = () => {
   const [muted, setMutedState] = useState(isMuted());
   const [isCloudLoading, setIsCloudLoading] = useState(!!user);
   const [autoFarm, setAutoFarm] = useState(false);
+  const [autoMerge, setAutoMerge] = useState(false);
+  const [isMerging, setIsMerging] = useState(false);
   const [farmStats, setFarmStats] = useState({ runs: 0, totalCoins: 0 });
   const [storyRegionIdx, setStoryRegionIdx] = useState(0);
   const huntSpeedRef = useRef(1);
@@ -423,6 +426,45 @@ const Index = () => {
     }));
   };
 
+  const mergeAll = useCallback(() => {
+    if (isMerging) return;
+    setIsMerging(true);
+    
+    let mergeCount = 0;
+    let currentHeroes = [...player.heroes];
+    let madeProgress = true;
+    
+    while (madeProgress) {
+      madeProgress = false;
+      for (const recipe of MERGE_RECIPES) {
+        const available = currentHeroes.filter(h => h.rarity === recipe.from);
+        if (available.length >= recipe.count) {
+          const toRemove = new Set(available.slice(0, recipe.count).map(h => h.id));
+          const newHero = generateHero(recipe.to);
+          currentHeroes = [...currentHeroes.filter(h => !toRemove.has(h.id)), newHero];
+          mergeCount++;
+          madeProgress = true;
+          break;
+        }
+      }
+    }
+    
+    if (mergeCount > 0) {
+      setPlayer(prev => ({ ...prev, heroes: currentHeroes }));
+      toast({
+        title: "Fusion terminée",
+        description: `${mergeCount} fusion(s) effectuée(s)`,
+      });
+    } else {
+      toast({
+        title: "Aucune fusion possible",
+        description: "Vous n'avez pas assez de héros pour fusionner",
+      });
+    }
+    
+    setIsMerging(false);
+  }, [player.heroes, isMerging]);
+
   const startStoryStage = (stage: StoryStage) => {
     const map = generateMap(stage.width, stage.height, stage.blockDensity, 0); // no chests in story
 
@@ -590,14 +632,40 @@ const Index = () => {
       batch.push(hero);
     }
 
+    let mergedHeroes = newHeroes;
+    if (autoMerge && (type === 'x10' || type === 'x100')) {
+      let mergeCount = 0;
+      let madeProgress = true;
+      while (madeProgress) {
+        madeProgress = false;
+        for (const recipe of MERGE_RECIPES) {
+          const available = mergedHeroes.filter(h => h.rarity === recipe.from);
+          if (available.length >= recipe.count) {
+            const toRemove = new Set(available.slice(0, recipe.count).map(h => h.id));
+            const newHero = generateHero(recipe.to);
+            mergedHeroes = [...mergedHeroes.filter(h => !toRemove.has(h.id)), newHero];
+            mergeCount++;
+            madeProgress = true;
+            break;
+          }
+        }
+      }
+      if (mergeCount > 0) {
+        toast({
+          title: "Fusion automatique",
+          description: `${mergeCount} fusion(s) effectuée(s) après invocation`,
+        });
+      }
+    }
+
     setLastSummoned(batch[batch.length - 1]);
     setSummonedBatch(batch);
     setPlayer(prev => ({
       ...prev,
       bomberCoins: newCoins,
-      heroes: newHeroes,
+      heroes: mergedHeroes,
       pityCounters: currentPity,
-      totalHeroesOwned: newHeroes.length,
+      totalHeroesOwned: mergedHeroes.length,
     }));
     saveHeroesToCloud(batch);
     setDailyQuests(prev => updateQuestProgress(prev, 'summon_heroes', count));
@@ -1302,6 +1370,28 @@ const Index = () => {
                   );
                 })}
               </div>
+            </div>
+
+            <div className="flex flex-col sm:flex-row gap-3 items-stretch sm:items-center justify-between">
+              <button 
+                onClick={mergeAll}
+                disabled={isMerging}
+                className={`pixel-btn pixel-btn-primary font-pixel text-[8px] flex items-center justify-center gap-2 min-h-[44px] ${isMerging ? 'opacity-50 cursor-not-allowed' : ''}`}
+              >
+                <Sparkles size={14} /> {isMerging ? 'Fusion en cours...' : 'Tout fusionner'}
+              </button>
+              
+              <label className="flex items-center gap-2 cursor-pointer min-h-[44px] px-3 pixel-border bg-muted/30 hover:bg-muted/50 transition-colors">
+                <input 
+                  type="checkbox" 
+                  checked={autoMerge}
+                  onChange={(e) => setAutoMerge(e.target.checked)}
+                  className="w-4 h-4 accent-primary"
+                />
+                <span className="font-pixel text-[7px] sm:text-[8px] text-muted-foreground">
+                  Fusion auto après invocation x10/x100
+                </span>
+              </label>
             </div>
 
             <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3">


### PR DESCRIPTION
## Summary
- Ajoute un bouton 'Tout fusionner' dans l'écran Héros pour fusionner tous les héros possibles en un seul clic
- Ajoute une option 'Fusion auto après invocation x10/x100' qui déclenche automatiquement les fusions après une invocation multiple
- Empêche les actions concurrentes avec un flag isMerging
- Affiche des notifications toast pour les résultats de fusion

## Détails techniques
- Le bouton applique en boucle la logique de fusion existante (sans duplication des règles métier)
- Le toggle est désactivé par défaut (OFF)
- Les cibles tactiles ont une taille minimale de 44px pour une bonne UX mobile

Closes #25