### PR TITLE
feat: popup pseudo obligatoire après login (issue #29)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Glossary from "./pages/Glossary";
 import Changelog from "./pages/Changelog";
 import ResetPassword from "./pages/ResetPassword";
 import NotFound from "./pages/NotFound";
+import UsernameRequiredDialog from "./components/UsernameRequiredDialog";
 
 const queryClient = new QueryClient();
 
@@ -27,6 +28,7 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
+            <UsernameRequiredDialog />
             <Routes>
             <Route path="/" element={<Landing />} />
             <Route path="/auth" element={<Auth />} />

--- a/src/components/UsernameRequiredDialog.tsx
+++ b/src/components/UsernameRequiredDialog.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useLocation } from 'react-router-dom';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/contexts/AuthContext';
+import { useProfile } from '@/contexts/ProfileContext';
+import { toast } from '@/hooks/use-toast';
+
+export default function UsernameRequiredDialog() {
+  const { user } = useAuth();
+  const { profile, loading, setDisplayName } = useProfile();
+  const location = useLocation();
+  const [value, setValue] = useState('');
+  const [saving, setSaving] = useState(false);
+
+  const open = useMemo(() => {
+    if (!user || loading) return false;
+    if (location.pathname === '/auth' || location.pathname === '/reset-password') return false;
+    return !profile?.display_name;
+  }, [user, loading, profile?.display_name, location.pathname]);
+
+  useEffect(() => {
+    if (open) setValue('');
+  }, [open]);
+
+  const submit = async () => {
+    setSaving(true);
+    const { error } = await setDisplayName(value);
+    setSaving(false);
+
+    if (error) {
+      toast({ title: 'Pseudo invalide', description: error, variant: 'destructive' });
+      return;
+    }
+
+    toast({ title: 'Pseudo enregistré', description: 'Ton profil est prêt ✅' });
+  };
+
+  return (
+    <Dialog open={open}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Choisis ton pseudo</DialogTitle>
+          <DialogDescription>
+            Ce pseudo sera visible en jeu (3-20 caractères, lettres/chiffres/underscore).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-3">
+          <Input
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            placeholder="ex: bomber_king"
+            maxLength={20}
+            autoFocus
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                submit();
+              }
+            }}
+          />
+          <Button className="w-full" onClick={submit} disabled={saving}>
+            {saving ? 'Enregistrement...' : 'Enregistrer mon pseudo'}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Résumé
- ajoute une modal bloquante tant que le pseudo n’est pas défini
- validation côté client (format) + contrôle d’unicité via profiles
- branchement global dans App pour couvrir les sessions connectées

## Vérification
- npm run build ✅

## Dépendance
- cette PR est stackée sur #38 (issue #37)

Refs #29