### PR TITLE
fix: supprimer friendly-fire des bombes + stamina à la pose (#50)

### DIFF
--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -388,7 +388,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
   // Process explosions from bombs
   for (const bomb of explodingBombs) {
     const tiles = getExplosionTiles(map, bomb.position, bomb.range);
-    explosions.push({ id: genId(), tiles, timer: 0.4 });
+    explosions.push({ id: genId(), tiles, timer: 0.4, team: bomb.team });
 
     for (const tile of tiles) {
       if (map.tiles[tile.y][tile.x] === 'block') {
@@ -419,13 +419,15 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
     for (const cb of chainedBombs) {
       bombs = bombs.filter(b => b.id !== cb.id);
       const cbTiles = getExplosionTiles(map, cb.position, cb.range);
-      explosions.push({ id: genId(), tiles: cbTiles, timer: 0.4 });
+      explosions.push({ id: genId(), tiles: cbTiles, timer: 0.4, team: cb.team });
     }
 
-    // Hero energy loss in explosion
-    for (const hero of heroes) {
-      if (tiles.some(t => t.x === Math.round(hero.position.x) && t.y === Math.round(hero.position.y)) && hero.state !== 'resting') {
-        hero.currentStamina = Math.max(0, hero.currentStamina - Math.floor(hero.maxStamina * 0.15));
+    // Explosion damage to heroes: only enemy bombs can hurt heroes
+    if (bomb.team === 'enemies') {
+      for (const hero of heroes) {
+        if (tiles.some(t => t.x === Math.round(hero.position.x) && t.y === Math.round(hero.position.y)) && hero.state !== 'resting') {
+          hero.currentStamina = Math.max(0, hero.currentStamina - Math.floor(hero.maxStamina * 0.15));
+        }
       }
     }
   }
@@ -535,8 +537,9 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
             range: hero.stats.rng,
             timer: 2.0,
             power: hero.stats.pwr,
+            team: 'heroes',
           });
-          hero.currentStamina -= 1;
+          hero.currentStamina = Math.max(0, hero.currentStamina - 1);
           hero.bombCooldown = 0.5;
           bombsPlaced++;
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -41,6 +41,8 @@ export interface Hero {
   icon: string; // icon key for PixelIcon
 }
 
+export type BombTeam = 'heroes' | 'enemies';
+
 export interface Bomb {
   id: string;
   heroId: string;
@@ -48,12 +50,14 @@ export interface Bomb {
   range: number;
   timer: number;
   power: number;
+  team: BombTeam;
 }
 
 export interface Explosion {
   id: string;
   tiles: { x: number; y: number }[];
   timer: number;
+  team: BombTeam;
 }
 
 export interface Chest {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -194,6 +194,7 @@ const Index = () => {
                 range: 2,
                 timer: 1.5,
                 power: Math.ceil(boss!.damage / 3),
+                team: 'enemies',
               });
             }
           });
@@ -211,26 +212,28 @@ const Index = () => {
           if (!processedExplosionsRef.current.has(exp.id)) {
             processedExplosionsRef.current.add(exp.id);
             SFX.explosion();
-            const heroPower = Math.max(...state.heroes.map(h => h.stats.pwr), 1);
-            const { enemies: updatedEnemies, kills } = damageEnemiesFromExplosion(enemies, exp.tiles, heroPower);
-            enemies = updatedEnemies;
-            enemiesKilled += kills;
-            if (kills > 0) {
-              SFX.enemyKill();
-              eventLog.push(`💥 ${kills} ennemi(s) éliminé(s)!`);
-              coinsEarned += kills * 10;
-            }
-
-            if (boss && boss.hp > 0) {
-              const prevHp = boss.hp;
-              boss = damageBossFromExplosion(boss, exp.tiles, heroPower + 1);
-              if (boss.hp < prevHp) {
-                SFX.bossHit();
-                eventLog.push(`💥 Boss touché! (${boss.hp}/${boss.maxHp} HP)`);
+            if (exp.team === 'heroes') {
+              const heroPower = Math.max(...state.heroes.map(h => h.stats.pwr), 1);
+              const { enemies: updatedEnemies, kills } = damageEnemiesFromExplosion(enemies, exp.tiles, heroPower);
+              enemies = updatedEnemies;
+              enemiesKilled += kills;
+              if (kills > 0) {
+                SFX.enemyKill();
+                eventLog.push(`💥 ${kills} ennemi(s) éliminé(s)!`);
+                coinsEarned += kills * 10;
               }
-              if (boss.hp <= 0 && prevHp > 0) {
-                eventLog.push(`👑 BOSS VAINCU!`);
-                coinsEarned += 500;
+
+              if (boss && boss.hp > 0) {
+                const prevHp = boss.hp;
+                boss = damageBossFromExplosion(boss, exp.tiles, heroPower + 1);
+                if (boss.hp < prevHp) {
+                  SFX.bossHit();
+                  eventLog.push(`💥 Boss touché! (${boss.hp}/${boss.maxHp} HP)`);
+                }
+                if (boss.hp <= 0 && prevHp > 0) {
+                  eventLog.push(`👑 BOSS VAINCU!`);
+                  coinsEarned += 500;
+                }
               }
             }
           }


### PR DESCRIPTION
## Résumé
Correctif ciblé du bug gameplay sur les bombes :
- suppression des dégâts alliés (incluant le poseur)
- conservation des dégâts sur le camp ennemi
- stamina consommée uniquement au moment de la pose de bombe

Closes #50

## Changements
- Ajout d'un camp de bombe (`heroes` / `enemies`) dans les types de jeu.
- Les explosions héritent du camp de la bombe source.
- Les dégâts d'explosion sur héros ne s'appliquent plus que pour les bombes ennemies (plus de friendly-fire entre héros, plus d'auto-dégât).
- Les dégâts sur ennemis / boss en mode histoire ne s'appliquent que pour les explosions du camp héros.
- La stamina à la pose est conservée et clampée (>= 0).

## Vérifications
- ✅ `npm run build`
- ✅ Vérif logique manuelle (lecture du flux de jeu) :
  - Héros lent + héros rapide touchés par explosion d'une bombe alliée : plus de perte de stamina.
  - Bombe boss (camp ennemi) : les héros peuvent toujours perdre de la stamina en zone d'explosion.
  - Les explosions des héros continuent d'infliger des dégâts aux ennemis et au boss.
