### PR TITLE
fix: adapt game map size to container width (issue #17)

### DIFF
--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -11,6 +11,7 @@ const TILE_SIZE = 40;
 
 const GameGrid: React.FC<GameGridProps> = ({ gameState }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
   const animFrameRef = useRef<number>(0);
 
   const draw = useCallback(() => {
@@ -208,12 +209,42 @@ const GameGrid: React.FC<GameGridProps> = ({ gameState }) => {
   }, [draw]);
 
   return (
-    <div className="relative overflow-auto rounded-lg bg-[hsl(var(--game-bg-deep))] p-1.5 shadow-[0_0_30px_rgba(0,0,0,0.5),inset_0_0_20px_rgba(0,0,0,0.3)]" style={{ border: '3px solid hsl(230, 20%, 22%)' }}>
-      <canvas
-        ref={canvasRef}
-        style={{ imageRendering: 'pixelated' }}
-        className="block rounded"
-      />
+    <div 
+      ref={containerRef}
+      className="relative w-full max-w-full overflow-hidden rounded-lg"
+      style={{ 
+        backgroundColor: 'hsl(var(--game-bg-deep))',
+        border: '3px solid hsl(230, 20%, 22%)',
+        boxShadow: '0 0 30px rgba(0,0,0,0.5),inset 0 0 20px rgba(0,0,0,0.3)',
+        aspectRatio: gameState ? `${gameState.map.width} / ${gameState.map.height}` : '13/9'
+      }}
+    >
+      {/* Background pattern for empty space */}
+      <div className="absolute inset-0 opacity-30 pointer-events-none" style={{
+        backgroundImage: `
+          linear-gradient(335deg, rgba(60,60,100,0.3) 23px, transparent 23px),
+          linear-gradient(155deg, rgba(80,80,120,0.3) 23px, transparent 23px),
+          linear-gradient(335deg, rgba(60,60,100,0.3) 23px, transparent 23px),
+          linear-gradient(155deg, rgba(80,80,120,0.3) 23px, transparent 23px)
+        `,
+        backgroundSize: '58px 58px',
+        backgroundPosition: '0 0, 4px 29px, 29px 4px, 33px 33px'
+      }} />
+      
+      {/* Canvas container with responsive scaling */}
+      <div className="absolute inset-0 flex items-center justify-center p-1.5">
+        <canvas
+          ref={canvasRef}
+          style={{ 
+            imageRendering: 'pixelated',
+            maxWidth: '100%',
+            maxHeight: '100%',
+            width: 'auto',
+            height: 'auto'
+          }}
+          className="block rounded"
+        />
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Make GameGrid responsive with aspect ratio preservation based on map dimensions
- Add decorative background pattern for lateral empty space (brick-like pattern)
- Scale canvas responsively while maintaining pixel-art rendering quality

## Changes
Modified `src/components/GameGrid.tsx`:
- Added `aspectRatio` CSS property to maintain map proportions
- Added background pattern overlay for empty space around the map
- Made canvas responsive with `max-width: 100%` and `max-height: 100%`

Fixes #17