### PR TITLE
Sync hunt speed preference to cloud for authenticated users

### DIFF
--- a/src/game/saveSystem.ts
+++ b/src/game/saveSystem.ts
@@ -25,6 +25,7 @@ export function getDefaultPlayerData(): PlayerData {
       legend: 0,
       'super-legend': 0,
     } as Record<Rarity, number>,
+    huntSpeed: 1,
   };
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -113,6 +113,7 @@ export interface PlayerData {
   totalHeroesOwned: number;
   mapsCompleted: number;
   shards: Record<Rarity, number>;
+  huntSpeed?: number;
 }
 
 export const RARITY_CONFIG: Record<Rarity, {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -31,15 +31,23 @@ const Index = () => {
   const { user, signOut } = useAuth();
   const navigate = useNavigate();
   const [screen, setScreen] = useState<Screen>('hub');
-  const [player, setPlayer] = useState<PlayerData>(() => loadPlayerData());
+  const [player, setPlayer] = useState<PlayerData>(() =>
+    user ? getDefaultPlayerData() : loadPlayerData()
+  );
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [summonOpen, setSummonOpen] = useState(false);
   const [lastSummoned, setLastSummoned] = useState<Hero | null>(null);
   const [selectedMap, setSelectedMap] = useState(0);
   const [selectedHeroes, setSelectedHeroes] = useState<Set<string>>(new Set());
   const [upgradeHeroId, setUpgradeHeroId] = useState<string | null>(null);
-  const [dailyQuests, setDailyQuests] = useState<DailyQuestData>(() => loadDailyQuests());
-  const [storyProgress, setStoryProgress] = useState<StoryProgress>(() => loadStoryProgress());
+  const [dailyQuests, setDailyQuests] = useState<DailyQuestData>(() =>
+    user ? generateDailyQuests() : loadDailyQuests()
+  );
+  const [storyProgress, setStoryProgress] = useState<StoryProgress>(() =>
+    user
+      ? { completedStages: [], currentRegion: 'forest', bossesDefeated: [], highestStage: 0 }
+      : loadStoryProgress()
+  );
   const [currentStoryStage, setCurrentStoryStage] = useState<StoryStage | null>(null);
   const [muted, setMutedState] = useState(isMuted());
   const [isCloudLoading, setIsCloudLoading] = useState(!!user);
@@ -52,9 +60,11 @@ const Index = () => {
   const gameLoopRef = useRef<number>();
 
   useEffect(() => {
-    const saved = Number(localStorage.getItem('hunt-speed') || '1');
-    const initialSpeed = saved === 2 || saved === 3 ? saved : 1;
-    huntSpeedRef.current = initialSpeed;
+    // For guests: restore speed from localStorage. For auth users: cloud load handles it.
+    if (!user) {
+      const saved = Number(localStorage.getItem('hunt-speed') || '1');
+      huntSpeedRef.current = saved === 2 || saved === 3 ? saved : 1;
+    }
   }, []);
   const lastTickRef = useRef<number>(Date.now());
   const processedExplosionsRef = useRef<Set<string>>(new Set());
@@ -72,15 +82,35 @@ const Index = () => {
     if (!user) return;
     loadFromCloud().then(data => {
       if (data) {
-        // Cloud data takes precedence over localStorage for authenticated users
+        // Cloud data is the single source of truth for authenticated users
         setPlayer(data.playerData);
-        setStoryProgress(data.storyProgress ?? loadStoryProgress());
+        setStoryProgress(data.storyProgress ?? { completedStages: [], currentRegion: 'forest', bossesDefeated: [], highestStage: 0 });
         // Regenerate quests if they are from a previous day
         const today = new Date().toISOString().split('T')[0];
         setDailyQuests(data.dailyQuests?.date === today ? data.dailyQuests : generateDailyQuests());
+        // Restore hunt speed preference from cloud
+        const cloudSpeed = data.playerData.huntSpeed;
+        if (cloudSpeed === 2 || cloudSpeed === 3) {
+          huntSpeedRef.current = cloudSpeed;
+        }
+      } else {
+        // No cloud save yet — migrate localStorage data to Supabase (first login after playing as guest)
+        const localData = loadPlayerData();
+        const localStory = loadStoryProgress();
+        const localQuests = loadDailyQuests();
+        setPlayer(localData);
+        setStoryProgress(localStory);
+        const today = new Date().toISOString().split('T')[0];
+        setDailyQuests(localQuests?.date === today ? localQuests : generateDailyQuests());
+        // Upload to cloud immediately so Supabase becomes the source of truth
+        saveStatsToCloud(localData, localStory, localQuests?.date === today ? localQuests : generateDailyQuests());
+        saveHeroesToCloud(localData.heroes);
+        const localSpeed = Number(localStorage.getItem('hunt-speed') || '1');
+        if (localSpeed === 2 || localSpeed === 3) {
+          huntSpeedRef.current = localSpeed;
+          setPlayer(prev => ({ ...prev, huntSpeed: localSpeed }));
+        }
       }
-      // If data is null (no cloud save yet), state already holds the localStorage values —
-      // no reset needed.
       setIsCloudLoading(false);
     });
   }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps
@@ -665,7 +695,10 @@ const Index = () => {
       pityCounters: currentPity,
       totalHeroesOwned: mergedHeroes.length,
     }));
-    saveHeroesToCloud(batch);
+    // Save all new heroes; if autoMerge removed some, delete them from Supabase too
+    saveHeroesToCloud(mergedHeroes.filter(h => !player.heroes.some(existing => existing.id === h.id)));
+    const removedByMerge = newHeroes.filter(h => !mergedHeroes.some(m => m.id === h.id)).map(h => h.id);
+    if (removedByMerge.length > 0) removeHeroesFromCloud(removedByMerge);
     setDailyQuests(prev => updateQuestProgress(prev, 'summon_heroes', count));
   };
 
@@ -1151,7 +1184,12 @@ const Index = () => {
                     onClick={() => {
                       const nextSpeed = gameState.speed === 1 ? 2 : gameState.speed === 2 ? 3 : 1;
                       huntSpeedRef.current = nextSpeed;
-                      localStorage.setItem('hunt-speed', String(nextSpeed));
+                      if (user) {
+                        // Persist speed preference in Supabase for authenticated users
+                        setPlayer(prev => ({ ...prev, huntSpeed: nextSpeed }));
+                      } else {
+                        localStorage.setItem('hunt-speed', String(nextSpeed));
+                      }
                       setGameState(prev => (prev ? { ...prev, speed: nextSpeed } : prev));
                     }}
                     className="font-pixel text-[8px] sm:text-[7px] px-3 py-2.5 sm:py-1.5 rounded transition-all bg-primary text-primary-foreground shadow-md min-w-[44px] sm:min-w-[38px] min-h-[44px] sm:min-h-[auto]"


### PR DESCRIPTION
## Résumé
Migre la préférence de vitesse de chasse (hunt speed) vers le cloud pour les utilisateurs authentifiés, tout en conservant localStorage pour les invités. Ajoute la gestion de la migration des données localStorage vers Supabase lors de la première connexion après avoir joué en tant qu'invité. Corrige également la sauvegarde des héros fusionnés dans le cloud.

## Issue liée (obligatoire)
Fixes #[numéro de l'issue]

## Type de changement
- [x] Feature
- [ ] Fix
- [x] Refactor
- [ ] UI/UX
- [ ] Balance
- [ ] Docs

## Détails des changements

### Synchronisation de la vitesse de chasse
- **Invités** : La vitesse est stockée dans `localStorage` comme avant
- **Utilisateurs authentifiés** : La vitesse est maintenant persistée dans `PlayerData.huntSpeed` et synchronisée via Supabase
- Lors du changement de vitesse, le code détecte si l'utilisateur est authentifié et met à jour soit Supabase soit localStorage

### Migration guest → authenticated
Quand un utilisateur authentifié se connecte pour la première fois (pas de données cloud) :
1. Les données localStorage (joueur, progression, quêtes, vitesse) sont chargées
2. Elles sont affichées immédiatement dans l'UI
3. Elles sont uploadées vers Supabase pour devenir la source de vérité
4. Les chargements ultérieurs utilisent les données cloud

### Corrections de sauvegarde des héros
- `saveHeroesToCloud()` sauvegarde maintenant uniquement les nouveaux héros (évite les doublons)
- Ajout de `removeHeroesFromCloud()` pour supprimer les héros fusionnés de Supabase
- Amélioration de la cohérence entre l'état local et le cloud

### Améliorations de robustesse
- Initialisation sécurisée de `storyProgress` avec des valeurs par défaut si absent du cloud
- Validation des valeurs de vitesse (2 ou 3) avant de les appliquer

## Vérifications
- [ ] J'ai testé localement
- [ ] Le build passe
- [ ] J'ai ajouté/ajusté les tests si nécessaire
- [ ] La PR est liée à une issue

## Notes complémentaires
**Migration** : Aucune migration de base de données requise. Les données existantes restent intactes, et la colonne `huntSpeed` est optionnelle dans `PlayerData`.

**Edge cases couverts** :
- Utilisateur invité → authentifié (migration localStorage)
- Utilisateur authentifié avec données cloud existantes
- Fusion de héros avec suppression du cloud
- Valeurs de vitesse invalides (rejet silencieux)

**Impact** : Améliore la persistance des préférences utilisateur et la cohérence des données entre appareils pour les utilisateurs authentifiés.

https://claude.ai/code/session_01FQWadd2ihDCgFxSajQasy1