### PR TITLE
feat: add Supabase profiles integration (fixes #37)

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,15 +1,19 @@
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
+import { getProfile, createProfileIfNotExists, updateProfileDisplayName, Profile } from '@/hooks/useProfile';
 
 interface AuthContextType {
   user: User | null;
   session: Session | null;
+  profile: Profile | null;
+  username: string | null;
   loading: boolean;
   signUp: (email: string, password: string, displayName?: string) => Promise<{ error: any }>;
   signIn: (email: string, password: string) => Promise<{ error: any }>;
   signInWithGoogle: () => Promise<{ error: any }>;
   signOut: () => Promise<void>;
+  updateUsername: (displayName: string) => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -23,26 +27,59 @@ export const useAuth = () => {
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
+  const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
 
+  const fetchProfile = useCallback(async (userId: string) => {
+    try {
+      const profileData = await getProfile(userId);
+      if (profileData) {
+        setProfile(profileData);
+      }
+    } catch (err) {
+      console.error('Error fetching profile:', err);
+    }
+  }, []);
+
+  const initializeProfile = useCallback(async (userId: string, displayName?: string) => {
+    try {
+      const profileData = await createProfileIfNotExists(userId, displayName);
+      setProfile(profileData);
+    } catch (err) {
+      console.error('Error initializing profile:', err);
+    }
+  }, []);
+
   useEffect(() => {
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_event, session) => {
       setSession(session);
-      setUser(session?.user ?? null);
+      const currentUser = session?.user ?? null;
+      setUser(currentUser);
+
+      if (currentUser) {
+        await fetchProfile(currentUser.id);
+      } else {
+        setProfile(null);
+      }
       setLoading(false);
     });
 
-    supabase.auth.getSession().then(({ data: { session } }) => {
+    supabase.auth.getSession().then(async ({ data: { session } }) => {
       setSession(session);
-      setUser(session?.user ?? null);
+      const currentUser = session?.user ?? null;
+      setUser(currentUser);
+
+      if (currentUser) {
+        await fetchProfile(currentUser.id);
+      }
       setLoading(false);
     });
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [fetchProfile]);
 
   const signUp = async (email: string, password: string, displayName?: string) => {
-    const { error } = await supabase.auth.signUp({
+    const { data, error } = await supabase.auth.signUp({
       email,
       password,
       options: {
@@ -50,6 +87,11 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
         data: { full_name: displayName },
       },
     });
+
+    if (!error && data.user) {
+      await initializeProfile(data.user.id, displayName);
+    }
+
     return { error };
   };
 
@@ -68,10 +110,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   const signOut = async () => {
     await supabase.auth.signOut();
+    setProfile(null);
   };
 
+  const updateUsername = async (displayName: string) => {
+    if (!user) return;
+    const updated = await updateProfileDisplayName(user.id, displayName);
+    setProfile(updated);
+  };
+
+  const username = profile?.display_name ?? null;
+
   return (
-    <AuthContext.Provider value={{ user, session, loading, signUp, signIn, signInWithGoogle, signOut }}>
+    <AuthContext.Provider value={{ user, session, profile, username, loading, signUp, signIn, signInWithGoogle, signOut, updateUsername }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/hooks/useProfile.ts
+++ b/src/hooks/useProfile.ts
@@ -1,0 +1,74 @@
+import { supabase } from '@/integrations/supabase/client';
+import type { Tables } from '@/integrations/supabase/types';
+
+export type Profile = Tables<'profiles'>;
+
+export const getProfile = async (userId: string): Promise<Profile | null> => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') return null;
+    console.error('Error fetching profile:', error);
+    throw error;
+  }
+
+  return data;
+};
+
+export const upsertProfile = async (
+  userId: string,
+  displayName: string | null
+): Promise<Profile> => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .upsert(
+      {
+        user_id: userId,
+        display_name: displayName,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error upserting profile:', error);
+    throw error;
+  }
+
+  return data;
+};
+
+export const updateProfileDisplayName = async (
+  userId: string,
+  displayName: string | null
+): Promise<Profile> => {
+  const { data, error } = await supabase
+    .from('profiles')
+    .update({ display_name: displayName, updated_at: new Date().toISOString() })
+    .eq('user_id', userId)
+    .select()
+    .single();
+
+  if (error) {
+    console.error('Error updating profile:', error);
+    throw error;
+  }
+
+  return data;
+};
+
+export const createProfileIfNotExists = async (
+  userId: string,
+  displayName?: string
+): Promise<Profile> => {
+  const existing = await getProfile(userId);
+  if (existing) return existing;
+
+  return upsertProfile(userId, displayName || null);
+};


### PR DESCRIPTION
## Summary
- Ajoute un hook `useProfile` avec fonctions utilitaires pour gérer les profils Supabase
- Intègre la création automatique de profil lors de l'inscription (signup avec displayName)
- Charge le profil existant lors du login (onAuthStateChange)
- Expose `profile` et `username` dans le `AuthContext` existant
- Ajoute la méthode `updateUsername` pour mettre à jour le display name

## Fichiers modifiés
- `src/hooks/useProfile.ts` (nouveau) - hook/service pour les profils
- `src/contexts/AuthContext.tsx` - ajouté profile, username, updateUsername

## Choix techniques
- Utilisation de la table `profiles` existante dans Supabase (types déjà générés)
- Le profil est créé via upsert pour éviter les doublons (onConflict: user_id)
- Gestion silencieuse des erreurs (console.error) pour ne pas bloquer l'auth
- Profile fetch dans onAuthStateChange pour couvrir tous les cas (signup, login, OAuth Google)

Fixes #37