### PR TITLE
Add profile page with account deletion (Fixes #30)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import Glossary from "./pages/Glossary";
 import Bestiary from "./pages/Bestiary";
 import Changelog from "./pages/Changelog";
 import ResetPassword from "./pages/ResetPassword";
+import Profile from "./pages/Profile";
 import NotFound from "./pages/NotFound";
 import UsernameRequiredDialog from "./components/UsernameRequiredDialog";
 
@@ -42,6 +43,7 @@ const App = () => (
             <Route path="/wiki/:slug" element={<WikiPage />} />
             <Route path="/changelog" element={<Changelog />} />
             <Route path="/reset-password" element={<ResetPassword />} />
+            <Route path="/profile" element={<Profile />} />
             {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
             <Route path="*" element={<NotFound />} />
             </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,7 +20,7 @@ import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
 import DailyQuests from '@/components/DailyQuests';
 import PixelIcon from '@/components/PixelIcon';
-import { Home, Users, Sparkles, Swords, Map, Trophy, Coins, Star, ChevronLeft, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Bomb, Lock as LockIcon, Volume2, VolumeX } from 'lucide-react';
+import { Home, Users, Sparkles, Swords, Map, Trophy, Coins, Star, ChevronLeft, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Bomb, Lock as LockIcon, Volume2, VolumeX, User } from 'lucide-react';
 import { SFX, isMuted, setMuted } from '@/game/sfx';
 import { toast } from '@/hooks/use-toast';
 
@@ -841,13 +841,22 @@ const Index = () => {
             <Users size={10} /> {player.heroes.length}
           </div>
           {user && (
-            <button
-              onClick={async () => { await signOut(); navigate('/'); }}
-              className="p-2 sm:p-1.5 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground min-w-[44px] sm:min-w-[auto] min-h-[36px] sm:min-h-[auto] flex items-center justify-center"
-              title="Déconnexion"
-            >
-              <DoorOpen size={16} />
-            </button>
+            <>
+              <button
+                onClick={() => navigate('/profile')}
+                className="p-2 sm:p-1.5 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground min-w-[44px] sm:min-w-[auto] min-h-[36px] sm:min-h-[auto] flex items-center justify-center"
+                title="Profil"
+              >
+                <User size={16} />
+              </button>
+              <button
+                onClick={async () => { await signOut(); navigate('/'); }}
+                className="p-2 sm:p-1.5 rounded hover:bg-muted transition-colors text-muted-foreground hover:text-foreground min-w-[44px] sm:min-w-[auto] min-h-[36px] sm:min-h-[auto] flex items-center justify-center"
+                title="Déconnexion"
+              >
+                <DoorOpen size={16} />
+              </button>
+            </>
           )}
         </div>
       </header>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,0 +1,231 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { useAuth } from '@/contexts/AuthContext';
+import { useProfile } from '@/contexts/ProfileContext';
+import { supabase } from '@/integrations/supabase/client';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { User, Loader2, AlertTriangle, LogOut, Trash2 } from 'lucide-react';
+import { toast } from '@/hooks/use-toast';
+
+export default function Profile() {
+  const { user, signOut } = useAuth();
+  const { profile, loading: profileLoading, setDisplayName, refreshProfile } = useProfile();
+  const navigate = useNavigate();
+  
+  const [displayName, setDisplayNameState] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [confirmUsername, setConfirmUsername] = useState('');
+  
+  useEffect(() => {
+    if (!user) {
+      navigate('/auth');
+      return;
+    }
+  }, [user, navigate]);
+  
+  useEffect(() => {
+    if (profile?.display_name) {
+      setDisplayNameState(profile.display_name);
+    }
+  }, [profile?.display_name]);
+  
+  const handleSaveUsername = async () => {
+    if (!displayName.trim()) return;
+    setSaving(true);
+    const { error } = await setDisplayName(displayName);
+    setSaving(false);
+    
+    if (error) {
+      toast({ title: 'Erreur', description: error, variant: 'destructive' });
+      return;
+    }
+    
+    toast({ title: 'Pseudo enregistré', description: 'Ton pseudo a été mis à jour.' });
+  };
+  
+  const handleDeleteAccount = async () => {
+    if (!user || !profile?.display_name) return;
+    if (confirmUsername !== profile.display_name) {
+      toast({ 
+        title: 'Confirmation incorrecte', 
+        description: 'Le pseudo doit correspondre exactement pour supprimer le compte.', 
+        variant: 'destructive' 
+      });
+      return;
+    }
+    
+    setDeleting(true);
+    
+    try {
+      const userId = user.id;
+      
+      await supabase.from('player_saves').delete().eq('user_id', userId);
+      await supabase.from('player_heroes').delete().eq('user_id', userId);
+      await supabase.from('profiles').delete().eq('user_id', userId);
+      
+      const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(userId);
+      
+      if (deleteAuthError) {
+        console.error('Error deleting auth user:', deleteAuthError);
+        toast({ 
+          title: 'Erreur', 
+          description: 'Impossible de supprimer le compte. Veuillez réessayer.', 
+          variant: 'destructive' 
+        });
+        setDeleting(false);
+        return;
+      }
+      
+      await signOut();
+      toast({ title: 'Compte supprimé', description: 'Ton compte a été supprimé avec succès.' });
+      navigate('/');
+    } catch (err) {
+      console.error('Error deleting account:', err);
+      toast({ 
+        title: 'Erreur', 
+        description: 'Une erreur est survenue lors de la suppression du compte.', 
+        variant: 'destructive' 
+      });
+      setDeleting(false);
+    }
+  };
+  
+  const handleSignOut = async () => {
+    await signOut();
+    navigate('/');
+  };
+  
+  if (!user) return null;
+  
+  return (
+    <div className="min-h-screen bg-background p-4">
+      <div className="max-w-2xl mx-auto space-y-6">
+        <motion.div 
+          initial={{ opacity: 0, y: 10 }} 
+          animate={{ opacity: 1, y: 0 }}
+          className="space-y-6"
+        >
+          <div className="text-center py-4">
+            <h1 className="font-pixel text-xl text-foreground">Profil</h1>
+            <p className="text-sm text-muted-foreground">Gère ton compte</p>
+          </div>
+          
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <User className="w-5 h-5" />
+                Informations du profil
+              </CardTitle>
+              <CardDescription>
+                Ton pseudo est visible en jeu
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Pseudo</label>
+                <div className="flex gap-2">
+                  <Input
+                    value={displayName}
+                    onChange={(e) => setDisplayNameState(e.target.value)}
+                    placeholder="Ton pseudo"
+                    maxLength={20}
+                    disabled={saving}
+                  />
+                  <Button onClick={handleSaveUsername} disabled={saving || !displayName.trim()}>
+                    {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Enregistrer'}
+                  </Button>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  3-20 caractères, lettres, chiffres et underscore uniquement
+                </p>
+              </div>
+              
+              <div className="space-y-2">
+                <label className="text-sm font-medium">Email</label>
+                <Input value={user.email || ''} disabled />
+                <p className="text-xs text-muted-foreground">
+                  L'email ne peut pas être modifié
+                </p>
+              </div>
+            </CardContent>
+          </Card>
+          
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <LogOut className="w-5 h-5" />
+                Déconnexion
+              </CardTitle>
+              <CardDescription>
+                Te déconnecter de ton compte
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button variant="outline" onClick={handleSignOut}>
+                <LogOut className="w-4 h-4 mr-2" />
+                Se déconnecter
+              </Button>
+            </CardContent>
+          </Card>
+          
+          <Card className="border-destructive/50">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2 text-destructive">
+                <AlertTriangle className="w-5 h-5" />
+                Zone dangereuse
+              </CardTitle>
+              <CardDescription>
+                La suppression du compte est irréversible
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Alert variant="destructive">
+                <AlertTriangle className="h-4 w-4" />
+                <AlertTitle>Attention</AlertTitle>
+                <AlertDescription>
+                  Cette action supprimera définitivement ton compte, tous tes héros et ta progression. Cette action est irréversible.
+                </AlertDescription>
+              </Alert>
+              
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Tape "{profile?.display_name || 'ton pseudo'}" pour confirmer
+                </label>
+                <Input
+                  value={confirmUsername}
+                  onChange={(e) => setConfirmUsername(e.target.value)}
+                  placeholder="Confirme ton pseudo"
+                  disabled={deleting}
+                />
+              </div>
+              
+              <Button 
+                variant="destructive" 
+                onClick={handleDeleteAccount}
+                disabled={deleting || confirmUsername !== profile?.display_name}
+                className="w-full"
+              >
+                {deleting ? (
+                  <>
+                    <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                    Suppression en cours...
+                  </>
+                ) : (
+                  <>
+                    <Trash2 className="w-4 h-4 mr-2" />
+                    Supprimer mon compte
+                  </>
+                )}
+              </Button>
+            </CardContent>
+          </Card>
+        </motion.div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add Profile page (`/profile`) with username editing functionality
- Add danger zone section for account deletion with username confirmation (user must type their username to activate delete button)
- Implement Supabase account deletion: removes user data from `player_saves`, `player_heroes`, `profiles` tables and deletes auth user via Admin API
- Add UX feedback with loading states, error handling, and success toasts
- Add profile link in game hub navigation (next to logout button)

## Changes
- `src/pages/Profile.tsx` - New profile page component
- `src/App.tsx` - Added `/profile` route
- `src/pages/Index.tsx` - Added User icon and profile navigation link