### PR TITLE
Fixes #56 - Bug d'affichage des barres de stamina en auto-farm

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1240,7 +1240,7 @@ const Index = () => {
                       <span className="font-pixel text-[7px] text-foreground truncate max-w-[60px]">{hero.name}</span>
                       <div className="w-16 h-1.5 bg-background rounded-full overflow-hidden">
                         <div
-                          className={`h-full transition-all duration-300 ${
+                          className={`h-full ${
                             isLow ? 'bg-game-energy-low' : 'bg-game-energy-green'
                           }`}
                           style={{ width: `${staminaPct}%` }}


### PR DESCRIPTION
## Summary
- Supprime la transition CSS `transition-all duration-300` sur les barres de stamina pour éviter le décalage visuel entre le texte et la barre en mode auto-farm

## Changes
- `src/pages/Index.tsx`: Enlevé la classe `transition-all duration-300` de la barre de stamina

Fixes #56