### PR TITLE
fix: prevent account init deadlock after profile/username rollout

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useEffect, useState, useCallback } from 'react';
+import React, { createContext, useContext, useEffect, useState, useCallback, useRef } from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { getProfile, createProfileIfNotExists, updateProfileDisplayName, Profile } from '@/hooks/useProfile';
@@ -24,20 +24,36 @@ export const useAuth = () => {
   return ctx;
 };
 
+const RETRY_DELAY_MS = 500;
+const MAX_RETRIES = 1;
+
+async function fetchProfileWithRetry(userId: string, retryCount = 0): Promise<Profile | null> {
+  try {
+    const profileData = await getProfile(userId);
+    return profileData;
+  } catch (err) {
+    const error = err as Error & { code?: string };
+    console.error('AUTH_PROFILE_FETCH_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
+    
+    if (retryCount < MAX_RETRIES) {
+      await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+      return fetchProfileWithRetry(userId, retryCount + 1);
+    }
+    return null;
+  }
+}
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
+  const initializedRef = useRef(false);
 
   const fetchProfile = useCallback(async (userId: string) => {
-    try {
-      const profileData = await getProfile(userId);
-      if (profileData) {
-        setProfile(profileData);
-      }
-    } catch (err) {
-      console.error('Error fetching profile:', err);
+    const profileData = await fetchProfileWithRetry(userId);
+    if (profileData) {
+      setProfile(profileData);
     }
   }, []);
 
@@ -46,11 +62,15 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
       const profileData = await createProfileIfNotExists(userId, displayName);
       setProfile(profileData);
     } catch (err) {
-      console.error('Error initializing profile:', err);
+      const error = err as Error & { code?: string };
+      console.error('AUTH_PROFILE_INIT_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
     }
   }, []);
 
   useEffect(() => {
+    if (initializedRef.current) return;
+    initializedRef.current = true;
+
     const { data: { subscription } } = supabase.auth.onAuthStateChange(async (_event, session) => {
       setSession(session);
       const currentUser = session?.user ?? null;
@@ -65,13 +85,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     });
 
     supabase.auth.getSession().then(async ({ data: { session } }) => {
-      setSession(session);
-      const currentUser = session?.user ?? null;
-      setUser(currentUser);
+      if (initializedRef.current === false) {
+        initializedRef.current = true;
+        setSession(session);
+        const currentUser = session?.user ?? null;
+        setUser(currentUser);
 
-      if (currentUser) {
-        await fetchProfile(currentUser.id);
+        if (currentUser) {
+          await fetchProfile(currentUser.id);
+        }
+        setLoading(false);
       }
+    }).catch((err) => {
+      console.error('AUTH_SESSION_GET_ERROR', { code: 'SESSION_GET_FAILED', message: err.message });
       setLoading(false);
     });
 

--- a/src/contexts/ProfileContext.tsx
+++ b/src/contexts/ProfileContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState, useRef } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 
@@ -18,6 +18,8 @@ interface ProfileContextType {
 }
 
 const USERNAME_RE = /^[A-Za-z0-9_]{3,20}$/;
+const RETRY_DELAY_MS = 500;
+const MAX_RETRIES = 1;
 
 const ProfileContext = createContext<ProfileContextType | undefined>(undefined);
 
@@ -31,41 +33,67 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({ child
   const { user } = useAuth();
   const [profile, setProfile] = useState<ProfileData | null>(null);
   const [loading, setLoading] = useState(false);
+  const loadingRef = useRef(false);
 
-  const ensureProfile = useCallback(async () => {
+  const ensureProfile = useCallback(async (retryCount = 0) => {
     if (!user?.id) {
       setProfile(null);
       return;
     }
 
+    if (loadingRef.current) return;
+    loadingRef.current = true;
     setLoading(true);
-    const { data: existing, error } = await supabase
-      .from('profiles')
-      .select('*')
-      .eq('user_id', user.id)
-      .maybeSingle();
 
-    if (error) {
+    try {
+      const { data: existing, error } = await supabase
+        .from('profiles')
+        .select('*')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (error) {
+        console.error('PROFILE_FETCH_ERROR', { code: error.code || 'UNKNOWN', message: error.message, userId: user.id });
+        
+        if (retryCount < MAX_RETRIES) {
+          await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+          loadingRef.current = false;
+          return ensureProfile(retryCount + 1);
+        }
+        setProfile(null);
+        return;
+      }
+
+      if (existing) {
+        setProfile(existing as ProfileData);
+        return;
+      }
+
+      const fallbackName = (user.user_metadata?.full_name as string | undefined)?.trim() || null;
+
+      const { data: inserted, error: insertError } = await supabase
+        .from('profiles')
+        .insert({ user_id: user.id, display_name: fallbackName })
+        .select('*')
+        .single();
+
+      if (insertError) {
+        console.error('PROFILE_INSERT_ERROR', { code: insertError.code || 'UNKNOWN', message: insertError.message, userId: user.id });
+        
+        if (retryCount < MAX_RETRIES) {
+          await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+          loadingRef.current = false;
+          return ensureProfile(retryCount + 1);
+        }
+        setProfile(null);
+        return;
+      }
+
+      setProfile((inserted as ProfileData) ?? null);
+    } finally {
+      loadingRef.current = false;
       setLoading(false);
-      return;
     }
-
-    if (existing) {
-      setProfile(existing as ProfileData);
-      setLoading(false);
-      return;
-    }
-
-    const fallbackName = (user.user_metadata?.full_name as string | undefined)?.trim() || null;
-
-    const { data: inserted } = await supabase
-      .from('profiles')
-      .insert({ user_id: user.id, display_name: fallbackName })
-      .select('*')
-      .single();
-
-    setProfile((inserted as ProfileData) ?? null);
-    setLoading(false);
   }, [user?.id]);
 
   useEffect(() => {
@@ -84,30 +112,39 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({ child
       return { error: 'Pseudo invalide (3-20 caractères, lettres/chiffres/underscore).' };
     }
 
-    const { data: conflictExists, error: conflictError } = await supabase.rpc('is_display_name_taken', {
-      p_display_name: normalized,
-      p_current_user_id: user.id,
-    });
+    try {
+      const { data: conflictExists, error: conflictError } = await supabase.rpc('is_display_name_taken', {
+        p_display_name: normalized,
+        p_current_user_id: user.id,
+      });
 
-    if (!conflictError && conflictExists) {
-      return { error: 'Ce pseudo est déjà utilisé.' };
-    }
-
-    const { data, error } = await supabase
-      .from('profiles')
-      .upsert({ user_id: user.id, display_name: normalized }, { onConflict: 'user_id' })
-      .select('*')
-      .single();
-
-    if (error) {
-      if (error.code === '23505' || error.message.includes('unique') || error.message.includes('duplicate')) {
-        return { error: 'Ce pseudo est déjà utilisé par un autre joueur.' };
+      if (conflictError) {
+        console.error('PROFILE_CHECK_CONFLICT_ERROR', { code: conflictError.code || 'UNKNOWN', message: conflictError.message });
+      } else if (conflictExists) {
+        return { error: 'Ce pseudo est déjà utilisé.' };
       }
+
+      const { data, error } = await supabase
+        .from('profiles')
+        .upsert({ user_id: user.id, display_name: normalized }, { onConflict: 'user_id' })
+        .select('*')
+        .single();
+
+      if (error) {
+        if (error.code === '23505' || error.message.includes('unique') || error.message.includes('duplicate')) {
+          return { error: 'Ce pseudo est déjà utilisé par un autre joueur.' };
+        }
+        console.error('PROFILE_UPDATE_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
+        return { error: 'Erreur technique. Veuillez réessayer plus tard.' };
+      }
+
+      setProfile(data as ProfileData);
+      return { error: null };
+    } catch (err) {
+      const error = err as Error & { code?: string };
+      console.error('PROFILE_SET_NAME_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
       return { error: 'Erreur technique. Veuillez réessayer plus tard.' };
     }
-
-    setProfile(data as ProfileData);
-    return { error: null };
   }, [user?.id]);
 
   const value = useMemo(() => ({

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -82,8 +82,10 @@ const Index = () => {
     if (!user) return;
 
     const CLOUD_LOAD_TIMEOUT = 10000;
+    const RETRY_DELAY_MS = 500;
+    const MAX_RETRIES = 1;
 
-    const loadWithTimeout = async () => {
+    const loadWithRetry = async (retryCount = 0): Promise<any> => {
       const timeoutPromise = new Promise<null>((resolve) => {
         setTimeout(() => resolve(null), CLOUD_LOAD_TIMEOUT);
       });
@@ -91,12 +93,19 @@ const Index = () => {
       try {
         const data = await Promise.race([loadFromCloud(), timeoutPromise]);
         return data;
-      } catch {
+      } catch (err) {
+        const error = err as Error & { code?: string };
+        console.error('CLOUD_LOAD_ERROR', { code: error.code || 'UNKNOWN', message: error.message, retryCount });
+        
+        if (retryCount < MAX_RETRIES) {
+          await new Promise(resolve => setTimeout(resolve, RETRY_DELAY_MS));
+          return loadWithRetry(retryCount + 1);
+        }
         return null;
       }
     };
 
-    loadWithTimeout().then(data => {
+    loadWithRetry().then(data => {
       if (data) {
         setPlayer(data.playerData);
         setStoryProgress(data.storyProgress ?? { completedStages: [], currentRegion: 'forest', bossesDefeated: [], highestStage: 0 });
@@ -125,8 +134,9 @@ const Index = () => {
           toast({ title: 'Cloud indisponible', description: 'Données chargées depuis le stockage local.', duration: 4000 });
         }
       }
-      setIsCloudLoading(false);
-    }).catch(() => {
+    }).catch((err) => {
+      const error = err as Error & { code?: string };
+      console.error('CLOUD_LOAD_UNEXPECTED_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
       const localData = loadPlayerData();
       const localStory = loadStoryProgress();
       const localQuests = loadDailyQuests();
@@ -135,6 +145,7 @@ const Index = () => {
       const today = new Date().toISOString().split('T')[0];
       setDailyQuests(localQuests?.date === today ? localQuests : generateDailyQuests());
       toast({ title: 'Cloud indisponible', description: 'Données chargées depuis le stockage local.', duration: 4000 });
+    }).finally(() => {
       setIsCloudLoading(false);
     });
   }, [user?.id]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -62,8 +62,8 @@ export default function Profile() {
   };
   
   const handleDeleteAccount = async () => {
-    if (!user || !profile?.display_name) return;
-    if (confirmUsername !== profile.display_name) {
+    if (!user || !profileDisplayName) return;
+    if (confirmUsername !== profileDisplayName) {
       toast({ 
         title: 'Confirmation incorrecte', 
         description: 'Le pseudo doit correspondre exactement pour supprimer le compte.', 
@@ -114,6 +114,9 @@ export default function Profile() {
   };
   
   if (!user) return null;
+  
+  const profileDisplayName = profile?.display_name ?? '';
+  const canDeleteAccount = confirmUsername === profileDisplayName && profileDisplayName.length > 0;
   
   return (
     <div className="min-h-screen bg-background p-4">
@@ -213,7 +216,7 @@ export default function Profile() {
               
               <div className="space-y-2">
                 <label className="text-sm font-medium">
-                  Tape "{profile?.display_name || 'ton pseudo'}" pour confirmer
+                  Tape "{profileDisplayName || 'ton pseudo'}" pour confirmer
                 </label>
                 <Input
                   value={confirmUsername}
@@ -226,7 +229,7 @@ export default function Profile() {
               <Button 
                 variant="destructive" 
                 onClick={handleDeleteAccount}
-                disabled={deleting || confirmUsername !== profile?.display_name}
+                disabled={deleting || !canDeleteAccount}
                 className="w-full"
               >
                 {deleting ? (


### PR DESCRIPTION
## Summary

Corrige la régression de chargement de compte après le merge des fonctionnalités profile/username.

### Causes racines identifiées

1. **Double appel concurrent** : `onAuthStateChange` et `getSession` appellent tous deux `fetchProfile`, créant des conditions de course
2. **Chargement bloquant** : les erreurs Supabase (profiles, RPC) n'étaient pas gérées de manière non-fatale
3. **État de loading oublié** : en cas d'erreur, `isCloudLoading` pouvait rester bloqué à `true`
4. **Profile null non géré** : la page Profile crashait si `profile` était `null`

### Corrections apportées

- **AuthContext** : ajout retry 1x (500ms), ajout `initializedRef` pour éviter double init, logs structurés
- **ProfileContext** : ajout retry 1x, `loadingRef` pour éviter appels concurrents, `finally` pour cleanup
- **Index.tsx** : ajout retry cloud loading, `finally` pour forcer `setIsCloudLoading(false)`
- **Profile.tsx** : gestion graceful du profile null (computed `profileDisplayName`, `canDeleteAccount`)

### Tests

- Build local réussi (`npm run build`)
- Vérifié que le fallback localStorage fonctionne quand Supabase échoue
- Le wording "cloud" est préservé dans les toasts

Fixes #62
