### PR TITLE
fix: restore reliable landing KPI loading

### DIFF
--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -292,7 +292,9 @@ interface LandingKpis {
   lastSuperLegend: string | null;
 }
 
-const KPI_TIMEOUT_MS = 4500;
+const KPI_TIMEOUT_MS = 8000;
+const KPI_RETRY_DELAY_MS = 1000;
+const KPI_MAX_RETRIES = 1;
 
 const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> => {
   return Promise.race([
@@ -301,6 +303,25 @@ const withTimeout = <T,>(promise: Promise<T>, ms: number): Promise<T> => {
       setTimeout(() => reject(new Error('KPI timeout')), ms)
     ),
   ]);
+};
+
+const withRetry = async <T,>(
+  fn: () => Promise<T>,
+  maxRetries: number,
+  delayMs: number
+): Promise<T> => {
+  let lastError: Error | null = null;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+      if (attempt < maxRetries) {
+        await new Promise(resolve => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+  throw lastError;
 };
 
 const KPI_FALLBACK: LandingKpis = {
@@ -331,34 +352,24 @@ const Landing: React.FC = () => {
       setKpisLoading(true);
       try {
         const kpiRequest = async () => {
-          const [playersResult, invocationsResult, lastSuperLegendResult] = await Promise.all([
-            supabase.from('profiles').select('id', { count: 'exact', head: true }),
-            supabase.from('player_heroes').select('id', { count: 'exact', head: true }),
-            supabase
-              .from('player_heroes')
-              .select('user_id, created_at')
-              .eq('rarity', 'super-legend')
-              .order('created_at', { ascending: false })
-              .limit(1)
-              .maybeSingle(),
-          ]);
-
-          let lastSuperLegendName: string | null = null;
-          if (lastSuperLegendResult.data?.user_id) {
-            const profileResult = await supabase
-              .from('profiles')
-              .select('display_name')
-              .eq('user_id', lastSuperLegendResult.data.user_id)
-              .maybeSingle();
-            lastSuperLegendName = profileResult.data?.display_name ?? null;
+          const { data, error } = await supabase.rpc('get_landing_stats');
+          
+          if (error) {
+            console.error('[KPI] RPC error:', {
+              code: error.code,
+              message: error.message,
+              details: error.details,
+              hint: error.hint
+            });
+            throw new Error(`KPI RPC failed: ${error.message}`);
           }
 
           if (!isMounted) return null;
 
           return {
-            players: playersResult.error ? null : (playersResult.count ?? null),
-            totalInvocations: invocationsResult.error ? null : (invocationsResult.count ?? null),
-            lastSuperLegend: lastSuperLegendName,
+            players: data?.players ?? null,
+            totalInvocations: data?.totalInvocations ?? null,
+            lastSuperLegend: data?.lastSuperLegend ?? null,
           };
         };
 
@@ -369,7 +380,11 @@ const Landing: React.FC = () => {
           }
         }, KPI_TIMEOUT_MS);
 
-        const result = await withTimeout(kpiRequest(), KPI_TIMEOUT_MS);
+        const result = await withRetry(
+          () => withTimeout(kpiRequest(), KPI_TIMEOUT_MS),
+          KPI_MAX_RETRIES,
+          KPI_RETRY_DELAY_MS
+        );
         clearTimeout(timeoutId);
 
         if (!isMounted) return;
@@ -379,8 +394,14 @@ const Landing: React.FC = () => {
         } else {
           setKpis(KPI_FALLBACK);
         }
-      } catch {
+      } catch (err) {
         if (!isMounted) return;
+        const error = err instanceof Error ? err : new Error(String(err));
+        console.error('[KPI] Load failed:', {
+          message: error.message,
+          stack: error.stack,
+          timestamp: new Date().toISOString()
+        });
         setKpis(KPI_FALLBACK);
       } finally {
         clearTimeout(timeoutId);

--- a/supabase/migrations/20260311170000_add_landing_stats_rpc.sql
+++ b/supabase/migrations/20260311170000_add_landing_stats_rpc.sql
@@ -1,0 +1,44 @@
+-- RPC function for landing page KPIs (public stats)
+-- Accessible without authentication via RLS bypass for SECURITY DEFINER
+
+CREATE OR REPLACE FUNCTION public.get_landing_stats()
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  result JSONB;
+  total_players BIGINT;
+  total_invocations BIGINT;
+  last_super_legend_user_id UUID;
+  last_super_legend_created_at TIMESTAMPTZ;
+  last_super_legend_name TEXT;
+BEGIN
+  -- Count total players (profiles)
+  SELECT COUNT(*)::BIGINT INTO total_players FROM public.profiles;
+
+  -- Count total hero invocations
+  SELECT COUNT(*)::BIGINT INTO total_invocations FROM public.player_heroes;
+
+  -- Get last super legend invocation with profile join
+  SELECT ph.user_id, ph.created_at, p.display_name
+  INTO last_super_legend_user_id, last_super_legend_created_at, last_super_legend_name
+  FROM public.player_heroes ph
+  LEFT JOIN public.profiles p ON p.user_id = ph.user_id
+  WHERE ph.rarity = 'super-legend'
+  ORDER BY ph.created_at DESC
+  LIMIT 1;
+
+  result := jsonb_build_object(
+    'players', COALESCE(total_players, 0),
+    'totalInvocations', COALESCE(total_invocations, 0),
+    'lastSuperLegend', last_super_legend_name
+  );
+
+  RETURN result;
+END;
+$$;
+
+-- Grant execute permission to anon (public)
+GRANT EXECUTE ON FUNCTION public.get_landing_stats() TO anon, authenticated;


### PR DESCRIPTION
## Summary

Corrige l'affichage des "Chiffres clés" sur la landing page qui restait vide en production.

## Cause racine

Les RLS (Row Level Security) sur les tables `profiles` et `player_heroes` limitaient l'accès aux propres données de l'utilisateur uniquement. Les requêtes KPI comptait tous les joueurs/héros sans filtre user_id, mais la RLS bloquait l'accès aux données des autres utilisateurs - donc les requêtes échouaient silencieusement.

## Corrections apportées

1. **Nouvelle fonction RPC `get_landing_stats()`** - Requête unique et sécurisée qui calcule les stats globales côté serveur (bypass RLS via SECURITY DEFINER)

2. **Amélioration du fetch KPI dans `Landing.tsx`:**
   - Retry: 1 tentative supplémentaire après 1s de délai
   - Timeout augmenté: 4.5s → 8s (tolerance cold start prod)
   - Logs d'erreur détaillés: code, message, details, timestamp
   - Bloc `finally` pour libérer le loading state

3. **Remplacement de 3 requêtes par 1 RPC** - Meilleure performance et fiabilité

## Tests effectués

- Build local: `npm run build` ✓
- Lint Landing.tsx: aucune erreur ✓

## Note de déploiement

La migration SQL `20260311170000_add_landing_stats_rpc.sql` doit être appliquée sur Supabase avant le déploiement du frontend.

Fixes #70
