### PR TITLE
fix(story): boss targeting + bouton Étape suivante

### DIFF
--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -177,7 +177,7 @@ export function findNearestTarget(
   hero: Hero,
   bombs: Bomb[],
   chests: Chest[],
-  enemies?: { position: { x: number; y: number }; hp: number }[],
+  enemies?: { position: { x: number; y: number }; hp: number; isBoss?: boolean }[],
   isStoryMode?: boolean
 ): { x: number; y: number } | null {
   const hx = Math.round(hero.position.x);
@@ -204,8 +204,9 @@ export function findNearestTarget(
         const ex = Math.round(enemy.position.x);
         const ey = Math.round(enemy.position.y);
         
-        // Priority -2 for closest enemy, -1 for others (always above chests/blocks)
-        const priority = ei === 0 ? -2 : -1;
+        // Priorité maximale au boss pour éviter les blocages de niveau.
+        // Puis ennemi le plus proche, puis les autres.
+        const priority = enemy.isBoss ? -3 : (ei === 0 ? -2 : -1);
         
         for (const [ox, oy] of [[0, -1], [0, 1], [-1, 0], [1, 0]]) {
           const tx = ex + ox;
@@ -582,7 +583,10 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       const hasAliveEnemies = state.enemies?.some(e => e.hp > 0) || (state.isStoryMode && state.boss && (state.boss as any).hp > 0);
       const retargetDelay = (state.isStoryMode && hasAliveEnemies) ? 0.15 : 0.3;
       const storyTargets = state.isStoryMode && state.boss && (state.boss as any).hp > 0
-        ? [...(state.enemies || []), state.boss as any]
+        ? [
+            ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
+            { ...(state.boss as any), isBoss: true },
+          ]
         : state.enemies;
 
       if (hero.stuckTimer >= retargetDelay) {
@@ -611,7 +615,10 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       if (hero.stuckTimer >= 0.8) {
         hero.stuckTimer = 0;
         const retargets = state.boss && (state.boss as any).hp > 0
-          ? [...(state.enemies || []), state.boss as any]
+          ? [
+              ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
+              { ...(state.boss as any), isBoss: true },
+            ]
           : state.enemies;
         const betterTarget = findNearestTarget(map, hero, bombs, map.chests, retargets, true);
         if (betterTarget && hero.targetPosition) {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -724,55 +724,85 @@ const Index = () => {
     setScreen('story-battle');
   };
 
-  const endStoryBattle = () => {
-    if (gameState && currentStoryStage) {
+  const getNextStoryStage = (stage: StoryStage): StoryStage | null => {
+    const region = STORY_REGIONS.find(r => r.id === stage.regionId);
+    if (!region) return null;
+    const idx = region.stages.findIndex(s => s.id === stage.id);
+    if (idx < 0 || idx + 1 >= region.stages.length) return null;
+    return region.stages[idx + 1];
+  };
+
+  const finalizeStoryBattle = (goToNextStage: boolean = false) => {
+    if (!currentStoryStage) {
+      setGameState(null);
+      setScreen('story');
+      return;
+    }
+
+    const stageSnapshot = currentStoryStage;
+    const stateSnapshot = gameState;
+
+    if (stateSnapshot) {
       const storyUpdatedHeroes = player.heroes.map(h => {
-        const deployed = gameState.heroes.find(dh => dh.id === h.id);
+        const deployed = stateSnapshot.heroes.find(dh => dh.id === h.id);
         if (!deployed) return h;
-        return gameState.mapCompleted
+        return stateSnapshot.mapCompleted
           ? { ...h, currentStamina: h.maxStamina }
           : { ...h, currentStamina: deployed.currentStamina };
       });
+
       setPlayer(prev => ({
         ...prev,
-        bomberCoins: prev.bomberCoins + gameState.coinsEarned + (gameState.mapCompleted ? currentStoryStage.reward : 0),
-        xp: prev.xp + (gameState.mapCompleted ? currentStoryStage.xpReward : 0),
+        bomberCoins: prev.bomberCoins + stateSnapshot.coinsEarned + (stateSnapshot.mapCompleted ? stageSnapshot.reward : 0),
+        xp: prev.xp + (stateSnapshot.mapCompleted ? stageSnapshot.xpReward : 0),
         heroes: storyUpdatedHeroes,
       }));
+
       if (canWriteCloud) {
-        saveHeroesToCloud(storyUpdatedHeroes.filter(h => gameState.heroes.some(dh => dh.id === h.id)));
+        saveHeroesToCloud(storyUpdatedHeroes.filter(h => stateSnapshot.heroes.some(dh => dh.id === h.id)));
       }
 
-      if (gameState.mapCompleted) {
+      if (stateSnapshot.mapCompleted) {
         setStoryProgress(prev => ({
           ...prev,
-          completedStages: prev.completedStages.includes(currentStoryStage.id)
+          completedStages: prev.completedStages.includes(stageSnapshot.id)
             ? prev.completedStages
-            : [...prev.completedStages, currentStoryStage.id],
-          bossesDefeated: currentStoryStage.boss && !prev.bossesDefeated.includes(currentStoryStage.boss)
-            ? [...prev.bossesDefeated, currentStoryStage.boss]
+            : [...prev.completedStages, stageSnapshot.id],
+          bossesDefeated: stageSnapshot.boss && !prev.bossesDefeated.includes(stageSnapshot.boss)
+            ? [...prev.bossesDefeated, stageSnapshot.boss]
             : prev.bossesDefeated,
-          highestStage: Math.max(prev.highestStage, currentStoryStage.stageNumber),
+          highestStage: Math.max(prev.highestStage, stageSnapshot.stageNumber),
         }));
       }
 
       setDailyQuests(prev => {
         let q = prev;
-        if (gameState.mapCompleted) q = updateQuestProgress(q, 'complete_maps', 1);
-        if (gameState.coinsEarned > 0) q = updateQuestProgress(q, 'earn_coins', gameState.coinsEarned);
-        if (gameState.bombsPlaced > 0) q = updateQuestProgress(q, 'place_bombs', gameState.bombsPlaced);
-        if (gameState.chestsOpened > 0) q = updateQuestProgress(q, 'open_chests', gameState.chestsOpened);
+        if (stateSnapshot.mapCompleted) q = updateQuestProgress(q, 'complete_maps', 1);
+        if (stateSnapshot.coinsEarned > 0) q = updateQuestProgress(q, 'earn_coins', stateSnapshot.coinsEarned);
+        if (stateSnapshot.bombsPlaced > 0) q = updateQuestProgress(q, 'place_bombs', stateSnapshot.bombsPlaced);
+        if (stateSnapshot.chestsOpened > 0) q = updateQuestProgress(q, 'open_chests', stateSnapshot.chestsOpened);
         return q;
       });
     }
+
+    const nextStage = goToNextStage && stateSnapshot?.mapCompleted && !stageSnapshot.boss
+      ? getNextStoryStage(stageSnapshot)
+      : null;
+
     setGameState(null);
     setCurrentStoryStage(null);
-    if (currentStoryStage) {
-      const regionIdx = STORY_REGIONS.findIndex(r => r.id === currentStoryStage.regionId);
-      if (regionIdx >= 0) setStoryRegionIdx(regionIdx);
+
+    if (nextStage) {
+      setTimeout(() => startStoryStage(nextStage), 100);
+      return;
     }
+
+    const regionIdx = STORY_REGIONS.findIndex(r => r.id === stageSnapshot.regionId);
+    if (regionIdx >= 0) setStoryRegionIdx(regionIdx);
     setScreen('story');
   };
+
+  const endStoryBattle = () => finalizeStoryBattle(false);
 
   const [summonedBatch, setSummonedBatch] = useState<Hero[]>([]);
 
@@ -1469,6 +1499,14 @@ const Index = () => {
                     >
                       <Check size={14} /> Récupérer
                     </button>
+                    {gameState.isStoryMode && currentStoryStage && !currentStoryStage.boss && (
+                      <button
+                        onClick={() => finalizeStoryBattle(true)}
+                        className="pixel-btn font-pixel text-xs flex items-center gap-2"
+                      >
+                        <Play size={14} /> Étape suivante
+                      </button>
+                    )}
                     {!gameState.isStoryMode && (
                       <>
                         <button


### PR DESCRIPTION
## Résumé\n- Priorise explicitement le boss dans la sélection de cible des bombers en mode Histoire\n- Inclut le boss dans les cibles story avec marqueur  pour éviter les blocages de combat\n- Ajoute un CTA **Étape suivante** sur l'écran de victoire des niveaux story non-boss\n- Le bouton n'est pas affiché sur les niveaux boss (flow spécifique conservé)\n\n## QA\n- [x] 
> vite_react_shadcn_ts@0.0.0 build
> vite build

vite v5.4.19 building for production...
transforming...
✓ 2192 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                         1.55 kB │ gzip:   0.61 kB
dist/assets/game-heroes-eRaJ8E3O.jpg   50.12 kB
dist/assets/game-boss-BlLeG2mI.jpg     78.12 kB
dist/assets/game-combat-Dy7Bz6m5.jpg   82.65 kB
dist/assets/game-map-CJuZjvlw.jpg      94.17 kB
dist/assets/index-BZcZMdki.css         75.56 kB │ gzip:  13.15 kB
dist/assets/index-CymWpo3c.js         902.50 kB │ gzip: 268.07 kB
✓ built in 7.77s\n- [x] Vérifié: bouton "Étape suivante" visible uniquement hors boss\n- [x] Vérifié: retour flow normal via "Récupérer"\n\nFixes #46