### PR TITLE
feat(ci): add UI evidence requirement for PRs (closes #85)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,14 @@ Exemple : `Fixes #17`
 - [ ] Refactor
 - [ ] Docs
 
+## Evidence (obligatoire pour UI/UX)
+Pour les changements UI/UX, joins des captures avant/après :
+- Crée un dossier `docs/evidence/issue-<id>/` (ex: `docs/evidence/issue-85/`)
+- Nomme les fichiers : `before.png`, `after.png` ou `before.webp`, `after.webp`
+- Ajoute les chemins dans cette section :
+  **Before:** 
+  **After:** 
+
 ## Vérifications
 - [ ] J’ai testé localement
 - [ ] Le build passe

--- a/.github/workflows/ui-evidence-check.yml
+++ b/.github/workflows/ui-evidence-check.yml
@@ -1,0 +1,75 @@
+name: UI Evidence Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited]
+    branches: [main]
+
+jobs:
+  check-ui-evidence:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for UI/UX changes
+        id: check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const labels = (pr.labels || []).map(l => typeof l === 'string' ? l : l.name);
+            
+            const isUI = labels.includes('UI/UX') || title.toLowerCase().includes('ui');
+            
+            // Check if PR body contains Evidence section with paths
+            const hasEvidenceSection = /##\s*Evidence/i.test(body);
+            const hasEvidencePaths = /\*\*(?:Before|After):\*\*/i.test(body);
+            
+            // Extract issue number from PR body
+            const issueMatch = body.match(/(?:fixes|closes|resolves)\s+#(\d+)/i);
+            const issueNumber = issueMatch ? issueMatch[1] : null;
+            
+            // Check if evidence files exist in docs/evidence/
+            let evidenceFilesExist = false;
+            if (issueNumber) {
+              const fs = require('fs');
+              const evidenceDir = `docs/evidence/issue-${issueNumber}`;
+              if (fs.existsSync(evidenceDir)) {
+                const files = fs.readdirSync(evidenceDir);
+                evidenceFilesExist = files.some(f => 
+                  f.match(/\.(png|webp|jpe?g|gif)$/i)
+                );
+              }
+            }
+            
+            core.setOutput('is_ui', String(isUI));
+            core.setOutput('has_evidence_section', String(hasEvidenceSection));
+            core.setOutput('has_evidence_paths', String(hasEvidencePaths));
+            core.setOutput('evidence_files_exist', String(evidenceFilesExist));
+            core.setOutput('issue_number', issueNumber || '');
+
+      - name: Fail if UI PR missing evidence
+        if: steps.check.outputs.is_ui == 'true' && (steps.check.outputs.has_evidence_section == 'false' || steps.check.outputs.has_evidence_paths == 'false' || steps.check.outputs.evidence_files_exist == 'false')
+        run: |
+          echo "❌ This PR is tagged UI/UX but is missing required evidence:"
+          if steps.check.outputs.has_evidence_section == 'false'
+            echo "  - Missing '## Evidence' section in PR description"
+          fi
+          if steps.check.outputs.has_evidence_paths == 'false'
+            echo "  - Missing 'Before:' and 'After:' paths in Evidence section"
+          fi
+          if steps.check.outputs.evidence_files_exist == 'false'
+            echo "  - Missing screenshot files in docs/evidence/issue-${{ steps.check.outputs.issue_number }}/"
+          fi
+          echo ""
+          echo "Please follow the Evidence section in the PR template."
+          exit 1
+
+      - name: Success message
+        if: steps.check.outputs.is_ui == 'false' || (steps.check.outputs.has_evidence_section == 'true' && steps.check.outputs.has_evidence_paths == 'true' && steps.check.outputs.evidence_files_exist == 'true')
+        run: echo "✅ UI evidence check passed"

--- a/docs/evidence/README.md
+++ b/docs/evidence/README.md
@@ -1,0 +1,38 @@
+# Evidence pour PR UI/UX
+
+## Convention de nommage
+
+Pour toute PR concernant l'UI/UX, des captures d'écran **avant** et **après** sont obligatoires.
+
+### Structure des fichiers
+
+```
+docs/evidence/
+└── issue-<numéro>/
+    ├── before.png   # Capture avant les changements
+    └── after.png    # Capture après les changements
+```
+
+### Formats acceptés
+
+- `.png` (recommandé)
+- `.webp`
+- `.jpg` / `.jpeg`
+- `.gif` (pour animations)
+
+### Instructions
+
+1. **Créer le dossier** : `docs/evidence/issue-<id>/` (ex: `docs/evidence/issue-85/`)
+2. **Nommer les fichiers** : `before.<ext>` et `after.<ext>`
+3. **Ajouter les chemins** dans la section Evidence de la PR :
+   ```markdown
+   ## Evidence
+   **Before:** docs/evidence/issue-85/before.png
+   **After:** docs/evidence/issue-85/after.png
+   ```
+
+### Pourquoi cette convention ?
+
+- Permet au reviewer de voir rapidement l'impact visuel
+- Archive les preuves dans le repo
+- Facilite le debugging et la traçabilité


### PR DESCRIPTION
## Résumé
Implémente le processus obligatoire de captures avant/après pour les PR UI/UX :
- Mise à jour du template de PR avec section Evidence obligatoire
- Ajout d'un workflow CI qui vérifie la présence de screenshots
- Documentation de la convention de nommage

## Changements
- `.github/pull_request_template.md` : ajout section Evidence
- `.github/workflows/ui-evidence-check.yml` : nouveau workflow CI
- `docs/evidence/README.md` : documentation de la convention

## Étapes de test
1. Créer une PR avec label UI/UX sans evidence → CI doit échouer
2. Créer une PR avec label UI/UX avec evidence → CI doit passer
3. Vérifier que le build passe (fait précédemment)

## Notes
- Choix simple : CI vérifie la section Evidence ET l'existence des fichiers dans `docs/evidence/issue-<id>/`
- Le workflow utilise `actions/github-script@v7` pour analyser le body de la PR