### PR TITLE
fix(story): corriger régressions issue #98 - friendly fire, KO defeat, stamina guards

### DIFF
--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -389,7 +389,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
   // Process explosions from bombs
   for (const bomb of explodingBombs) {
     const tiles = getExplosionTiles(map, bomb.position, bomb.range);
-    explosions.push({ id: genId(), tiles, timer: 0.4, team: bomb.team });
+    explosions.push({ id: genId(), tiles, timer: 0.4, team: bomb.team, heroId: bomb.heroId });
 
     for (const tile of tiles) {
       if (map.tiles[tile.y][tile.x] === 'block') {
@@ -420,7 +420,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
     for (const cb of chainedBombs) {
       bombs = bombs.filter(b => b.id !== cb.id);
       const cbTiles = getExplosionTiles(map, cb.position, cb.range);
-      explosions.push({ id: genId(), tiles: cbTiles, timer: 0.4, team: cb.team });
+      explosions.push({ id: genId(), tiles: cbTiles, timer: 0.4, team: cb.team, heroId: cb.heroId });
     }
 
     // Explosion damage to heroes: only enemy bombs can hurt heroes
@@ -441,6 +441,16 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
   // Update heroes
   for (let i = 0; i < heroes.length; i++) {
     const hero = heroes[i];
+
+    // GUARD: Story mode - ensure any hero with 0 stamina stays KO
+    if (state.isStoryMode && hero.currentStamina <= 0) {
+      hero.currentStamina = 0;
+      hero.state = 'resting';
+      hero.isActive = false;
+      hero.targetPosition = null;
+      hero.path = null;
+      continue;
+    }
 
     if (hero.state === 'resting') {
       if (state.isStoryMode) {
@@ -470,6 +480,10 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       hero.isActive = false;
       hero.targetPosition = null;
       hero.path = null;
+      // Story mode: explicitly prevent any respawn
+      if (state.isStoryMode) {
+        hero.isActive = false;
+      }
       continue;
     }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -58,6 +58,7 @@ export interface Explosion {
   tiles: { x: number; y: number }[];
   timer: number;
   team: BombTeam;
+  heroId?: string;
 }
 
 export interface Chest {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -424,6 +424,22 @@ const Index = () => {
                   coinsEarned += 500;
                 }
               }
+
+              // Friendly fire en mode histoire: bombes alliées blessent les autres héros
+              if (state.isStoryMode) {
+                for (const h of heroes) {
+                  // Ne pas blesser le héros qui a posé la bombe
+                  if (h.id === exp.heroId) continue;
+                  if (h.state === 'resting') continue;
+                  const hx = Math.round(h.position.x);
+                  const hy = Math.round(h.position.y);
+                  if (exp.tiles.some(t => t.x === hx && t.y === hy)) {
+                    const damage = Math.floor(h.maxStamina * 0.15);
+                    h.currentStamina = Math.max(0, h.currentStamina - damage);
+                    eventLog.push(`💥 ${h.name} blessé par bombe alliée! -${damage} ST`);
+                  }
+                }
+              }
             }
           }
         }
@@ -456,8 +472,8 @@ const Index = () => {
         const bossDefeated = !boss || boss.hp <= 0;
         const storyComplete = allEnemiesDead && bossDefeated;
 
-        // Check story defeat: all heroes KO (stamina = 0)
-        const allHeroesKO = heroes.every(h => h.currentStamina <= 0);
+        // Check story defeat: all heroes KO (stamina = 0 AND isActive = false)
+        const allHeroesKO = heroes.every(h => h.currentStamina <= 0 && !h.isActive);
         const storyFailed = allHeroesKO && !storyComplete && !state.mapCompleted;
 
         if (storyComplete && !state.mapCompleted) {


### PR DESCRIPTION
## Résumé des causes racines

L'issue #98 rapportait 3 régressions en mode Story :

1. **Stamina remonte (respawn implicite)** : Le code `tickGame` dans `engine.ts` n'avait pas de garde explicite pour maintenir les héros KO en mode Story. J'ai ajouté deux gardes :
   - Au début de la boucle de mise à jour des héros : si `isStoryMode` et `stamina <= 0`, le héros est immédiatement mis KO
   - Après la transition vers `resting` : vérification supplémentaire pour `isStoryMode`

2. **Friendly fire allié actif** : Les bombes des héros (team: 'heroes') n'infligeaient aucun dégât aux autres héros. J'ai ajouté :
   - Extension du type `Explosion` avec `heroId` optionnel (`types.ts:61`)
   - Propagation du `heroId` dans les explosions (`engine.ts:392,423`)
   - Logique de friendly fire en mode Story dans le game loop (`Index.tsx:427-441`)

3. **Défaite KO totale non déclenchée** : La condition de défaite vérifiait uniquement `currentStamina <= 0` sans vérifier `isActive`. J'ai corrigé à `h.currentStamina <= 0 && !h.isActive` (`Index.tsx:476`).

## Checklist de tests manuels

- [ ] **Stamina** : Lancer un stage Story avec plusieurs héros, tuer un héros (stamina = 0), vérifier qu'il reste KO et ne se régénère jamais pendant le stage
- [ ] **Friendly fire** : Déployer 2+ héros en Story, placer une bombe près d'un autre héros, vérifier que l'explosion blesser l'autre héros ( logs: "blessé par bombe alliée")
- [ ] **KO total** : Tuer tous les héros d'un équipe en Story, vérifier que la bannière "DÉFAITE! Tous les héros sont KO!" apparaît
- [ ] **Non-régression Treasure Hunt** : Vérifier que le comportement normal (regen stamina, pas de friendly fire) fonctionne toujours en mode Treasure Hunt

## Notes

- Comportement le plus strict côté Story difficulty appliqué (pas de respawn possible)
- Les autres modes (Treasure Hunt) restent inchangés

Fixes #98