### PR TITLE
fix(cloud): unblock write-back after rollback guard

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -211,9 +211,11 @@ const Index = () => {
           const localQuests = loadDailyQuests();
           const today = new Date().toISOString().split('T')[0];
           setDailyQuests(localQuests?.date === today ? localQuests : generateDailyQuests());
-          setCloudValidated(false);
+          // Keep local state (newer than cloud) and allow a write-back to heal cloud drift.
+          // Blocking writes here caused users to stay in permanent "Sync cloud en attente" mode.
+          setCloudValidated(true);
           cloudLoadedRef.current = true;
-          toast({ title: 'Sync cloud en attente', description: 'Sauvegarde locale conservée. Écriture cloud bloquée temporairement.', duration: 4500 });
+          toast({ title: 'Sync cloud en cours', description: 'Sauvegarde locale conservée. Mise à jour cloud en arrière-plan.', duration: 4500 });
           return;
         }
 


### PR DESCRIPTION
## Summary\n- keep local-first rollback protection when cloud snapshot looks stale\n- stop forcing cloud write lock in this guarded path\n- allow background cloud write-back so sync can self-heal\n- update toast copy to reflect active recovery sync\n\n## Why\nUsers could get stuck in repeated `Sync cloud en attente` state because writes stayed blocked after rollback guard was triggered.\n\n## Validation\n- npm run build\n\nFixes cloud sync lock regression.