### PR TITLE
fix: prevent NaN XP and restore XP gains for legacy heroes

### DIFF
--- a/src/game/saveSystem.ts
+++ b/src/game/saveSystem.ts
@@ -47,6 +47,12 @@ export function loadPlayerData(): PlayerData {
       if (!parsed.achievements) {
         parsed.achievements = getDefaultAchievementState();
       }
+      if (Array.isArray(parsed.heroes)) {
+        parsed.heroes = parsed.heroes.map((hero: any) => ({
+          ...hero,
+          xp: Number.isFinite(Number(hero?.xp)) ? Number(hero.xp) : 0,
+        }));
+      }
       return parsed;
     }
   } catch {

--- a/src/game/upgradeSystem.ts
+++ b/src/game/upgradeSystem.ts
@@ -299,6 +299,7 @@ export function canLevelUp(hero: Hero): boolean {
 export function getXpProgress(hero: Hero): { current: number; required: number; percentage: number } {
   const maxLevel = getMaxLevel(hero.rarity);
   const maxXp = getXpForLevel(maxLevel);
+  const heroXp = Number.isFinite(hero.xp) ? hero.xp : 0;
 
   if (hero.level >= maxLevel) {
     return { current: maxXp, required: maxXp, percentage: 100 };
@@ -306,8 +307,8 @@ export function getXpProgress(hero: Hero): { current: number; required: number; 
 
   const required = getXpForLevel(hero.level + 1);
   const prevRequired = getXpForLevel(hero.level);
-  const progress = hero.xp - prevRequired;
-  const needed = required - prevRequired;
+  const progress = Math.max(0, heroXp - prevRequired);
+  const needed = Math.max(1, required - prevRequired);
   const percentage = Math.min(100, Math.max(0, (progress / needed) * 100));
   return { current: progress, required: needed, percentage };
 }
@@ -316,8 +317,10 @@ export function addXp(hero: Hero, xp: number): Hero {
   const maxLevel = getMaxLevel(hero.rarity);
   if (hero.level >= maxLevel) return hero;
 
+  const baseXp = Number.isFinite(hero.xp) ? hero.xp : 0;
+  const earnedXp = Number.isFinite(xp) ? xp : 0;
   const maxXp = getXpForLevel(maxLevel);
-  const newXp = Math.min(hero.xp + xp, maxXp);
+  const newXp = Math.min(baseXp + earnedXp, maxXp);
   let newLevel = hero.level;
 
   while (newLevel < maxLevel && newXp >= getXpForLevel(newLevel + 1)) {

--- a/src/hooks/useCloudSave.ts
+++ b/src/hooks/useCloudSave.ts
@@ -31,6 +31,7 @@ function rowToHero(row: any): Hero {
     rarity: row.rarity,
     level: row.level,
     stars: row.stars,
+    xp: Number.isFinite(Number(row.xp)) ? Number(row.xp) : 0,
     stats: row.stats,
     skills: row.skills,
     currentStamina: Number(row.current_stamina),


### PR DESCRIPTION
## Résumé\nCorrige un bug où certains héros affichaient  et ne gagnaient plus d'XP.\n\n## Root cause\n- Certains héros chargés depuis d'anciennes sauvegardes (local/cloud) n'avaient pas la propriété .\n-  faisait , ce qui produisait  et cassait toute la progression XP.\n\n## Correctifs\n- \n  - hardening de  (fallback XP à 0 + bornes sûres)\n  - hardening de  (fallback / invalides à 0)\n- \n  -  initialise  à 0 si absent/invalide\n- \n  - migration soft au chargement local : force  à 0 si absent/invalide\n\n## Validation\n- 
> vite_react_shadcn_ts@0.0.0 build
> vite build

vite v5.4.19 building for production...
transforming...
✓ 2200 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                         1.55 kB │ gzip:   0.60 kB
dist/assets/game-heroes-eRaJ8E3O.jpg   50.12 kB
dist/assets/game-boss-BlLeG2mI.jpg     78.12 kB
dist/assets/game-combat-Dy7Bz6m5.jpg   82.65 kB
dist/assets/game-map-CJuZjvlw.jpg      94.17 kB
dist/assets/index-DTRcTOJD.css         77.37 kB │ gzip:  13.46 kB
dist/assets/index-BooC32tI.js         945.07 kB │ gzip: 279.94 kB
✓ built in 8.01s ✅\n\n## Impact\n- Plus de  dans la barre de progression XP\n- Les héros legacy recommencent à gagner de l'XP correctement\n