### PR TITLE
feat: augmenter les prix d’invocation x10 (issue #92)

### DIFF
--- a/docs/evidence/issue-92/price-changes.md
+++ b/docs/evidence/issue-92/price-changes.md
@@ -1,0 +1,28 @@
+# Issue #92 - Game Economy: Augmenter les prix d'invocation x10
+
+## Changes Made
+
+### Prices Updated (multiplied by 10):
+
+| Pull Type | Old Price | New Price |
+|-----------|-----------|-----------|
+| ×1        | 100       | 1,000     |
+| ×10       | 900       | 9,000     |
+| ×100      | 8,000     | 80,000    |
+
+### Files Modified
+
+1. **src/pages/Index.tsx** (line 1104)
+   - Updated `handleSummon` cost calculation
+
+2. **src/components/SummonModal.tsx** (lines 368, 373, 378, 383, 388, 394)
+   - Updated button disabled conditions
+   - Updated displayed price labels
+
+### Build Status
+- ✅ Build successful
+
+### Validations
+- All prices now 10x higher
+- No breaking changes to game logic
+- Prices updated consistently across all UI components

--- a/src/components/SummonModal.tsx
+++ b/src/components/SummonModal.tsx
@@ -365,33 +365,33 @@ const SummonModal: React.FC<SummonModalProps> = ({ isOpen, onClose, onSummon, co
           <div className="flex gap-2 flex-wrap">
             <button
               onClick={() => handleSummon('single')}
-              disabled={coins < 100 || animating}
+              disabled={coins < 1000 || animating}
               className="pixel-btn flex-1 text-center disabled:opacity-40"
             >
               <div className="font-pixel text-[8px]">×1</div>
               <div className="font-pixel text-[9px] mt-0.5 flex items-center justify-center gap-1">
-                <PixelIcon icon="coins" size={10} /> 100
+                <PixelIcon icon="coins" size={10} /> 1000
               </div>
             </button>
             <button
               onClick={() => handleSummon('x10')}
-              disabled={coins < 900 || animating}
+              disabled={coins < 9000 || animating}
               className="pixel-btn pixel-btn-gold flex-1 text-center disabled:opacity-40"
             >
               <div className="font-pixel text-[8px]">×10</div>
               <div className="font-pixel text-[9px] mt-0.5 flex items-center justify-center gap-1">
-                <PixelIcon icon="coins" size={10} /> 900
+                <PixelIcon icon="coins" size={10} /> 9000
               </div>
             </button>
             <button
               onClick={() => handleSummon('x100')}
-              disabled={coins < 8000 || animating}
+              disabled={coins < 80000 || animating}
               className="pixel-btn flex-1 text-center disabled:opacity-40"
               style={{ background: 'linear-gradient(135deg, hsl(var(--game-rarity-epic)), hsl(var(--game-rarity-legend)))' }}
             >
               <div className="font-pixel text-[8px] text-white">×100</div>
               <div className="font-pixel text-[9px] mt-0.5 flex items-center justify-center gap-1 text-white">
-                <PixelIcon icon="coins" size={10} /> 8000
+                <PixelIcon icon="coins" size={10} /> 80000
               </div>
             </button>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1101,7 +1101,7 @@ const Index = () => {
   const [summonedBatch, setSummonedBatch] = useState<Hero[]>([]);
 
   const handleSummon = (type: 'single' | 'x10' | 'x100') => {
-    const cost = type === 'single' ? 100 : type === 'x10' ? 900 : 8000;
+    const cost = type === 'single' ? 1000 : type === 'x10' ? 9000 : 80000;
     if (player.bomberCoins < cost) return;
 
     const count = type === 'single' ? 1 : type === 'x10' ? 10 : 100;


### PR DESCRIPTION
## Résumé\n- Augmente les coûts d’invocation x1/x10/x100 par facteur 10\n- Met à jour les textes UI associés\n- Ajoute une preuve dans docs/evidence/issue-92\n\nFixes #92\n\n## Validation\n- npm run build