### PR TITLE
feat: initialiser les stats de progression des héros invoqués (issue #55)

### DIFF
--- a/src/game/summoning.ts
+++ b/src/game/summoning.ts
@@ -87,6 +87,13 @@ export function generateHero(rarity: Rarity): Hero {
     bombCooldown: 0,
     stuckTimer: 0,
     icon,
+    progressionStats: {
+      chestsOpened: 0,
+      totalDamageDealt: 0,
+      battlesPlayed: 0,
+      victories: 0,
+      obtainedAt: Date.now(),
+    },
   };
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -20,6 +20,14 @@ export interface Skill {
   effect: string;
 }
 
+export interface HeroProgressionStats {
+  chestsOpened: number;
+  totalDamageDealt: number;
+  battlesPlayed: number;
+  victories: number;
+  obtainedAt: number; // timestamp
+}
+
 export interface Hero {
   id: string;
   name: string;
@@ -40,6 +48,7 @@ export interface Hero {
   bombCooldown: number;
   stuckTimer: number;
   icon: string; // icon key for PixelIcon
+  progressionStats: HeroProgressionStats;
 }
 
 export const MAX_LEVEL_BY_RARITY: Record<Rarity, number> = {


### PR DESCRIPTION
## Résumé\n- ajoute un type `HeroProgressionStats`\n- étend `Hero` avec `progressionStats`\n- initialise ces stats à la génération d’un héros invoqué (zéro + timestamp)\n\n## Validation\n- npm run build (worktree /tmp/bq-issue55-night) ✅\n\nCloses #55