### PR TITLE
feat: vrais visuels héros par clan + skins avec fallback legacy

### DIFF
--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -185,6 +185,7 @@ const GameGrid: React.FC<GameGridProps> = ({ gameState }) => {
         hero.id,
         hero.currentStamina,
         hero.maxStamina,
+        hero.name,
       );
     }
 

--- a/src/components/HeroAvatar.tsx
+++ b/src/components/HeroAvatar.tsx
@@ -4,6 +4,7 @@ import { Rarity } from '@/game/types';
 
 interface HeroAvatarProps {
   heroId?: string;
+  heroName?: string;
   rarity: Rarity;
   size?: number;
   className?: string;
@@ -11,7 +12,8 @@ interface HeroAvatarProps {
 }
 
 const HeroAvatar: React.FC<HeroAvatarProps> = ({ 
-  heroId, 
+  heroId,
+  heroName,
   rarity, 
   size = 40, 
   className = '',
@@ -37,7 +39,7 @@ const HeroAvatar: React.FC<HeroAvatarProps> = ({
     const draw = (time: number) => {
       offscreenCtx.clearRect(0, 0, PORTRAIT_BASE_SIZE, PORTRAIT_BASE_SIZE);
       offscreenCtx.imageSmoothingEnabled = false;
-      drawHeroPortrait(offscreenCtx, rarity, time, heroId);
+      drawHeroPortrait(offscreenCtx, rarity, time, heroId, heroName);
 
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.imageSmoothingEnabled = false;
@@ -69,7 +71,7 @@ const HeroAvatar: React.FC<HeroAvatarProps> = ({
     } else {
       draw(0);
     }
-  }, [heroId, rarity, animated]);
+  }, [heroId, heroName, rarity, animated]);
 
   return (
     <canvas

--- a/src/components/HeroCard.tsx
+++ b/src/components/HeroCard.tsx
@@ -50,7 +50,7 @@ const HeroCard: React.FC<HeroCardProps> = ({ hero, compact, onClick, selected })
         }`} style={{
           boxShadow: selected ? `0 0 10px hsl(var(--game-rarity-${hero.rarity}) / 0.4)` : 'none'
         }}>
-          <HeroAvatar heroId={hero.id} rarity={hero.rarity} size={44} />
+          <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={44} />
         </div>
 
         <div className="text-left flex-1 min-w-0">
@@ -106,7 +106,7 @@ const HeroCard: React.FC<HeroCardProps> = ({ hero, compact, onClick, selected })
       <div className="text-center mb-2 relative">
         <div className="inline-flex items-center justify-center w-16 h-16 rounded-lg bg-muted mb-1 group-hover:scale-110 transition-transform"
           style={{ boxShadow: `0 0 15px hsl(var(--game-rarity-${hero.rarity}) / 0.3)` }}>
-          <HeroAvatar heroId={hero.id} rarity={hero.rarity} size={64} />
+          <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={64} />
         </div>
         <h3 className="font-pixel text-[9px] text-foreground">{hero.name}</h3>
         <span className="text-[10px] font-pixel" style={{ color: `hsl(var(--game-rarity-${hero.rarity}))` }}>

--- a/src/components/SummonModal.tsx
+++ b/src/components/SummonModal.tsx
@@ -117,7 +117,7 @@ const HeroRevealCard: React.FC<{ hero: Hero; index: number; total: number }> = (
         className="rounded-lg p-2 mb-1 bg-card pixel-border flex items-center justify-center"
         style={{ boxShadow: `0 0 25px ${rarityGlows[hero.rarity]}`, width: avatarSize + 16, height: avatarSize + 16 }}
       >
-        <HeroAvatar heroId={hero.id} rarity={hero.rarity} size={avatarSize} />
+        <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={avatarSize} />
       </div>
       <p className="font-pixel text-[8px] text-foreground truncate max-w-[70px] text-center">{hero.name}</p>
       <p

--- a/src/game/heroRenderer.ts
+++ b/src/game/heroRenderer.ts
@@ -1,7 +1,8 @@
 // Pixel-art hero sprite renderer for canvas
 // Each hero gets a unique look based on rarity with proper body parts
 
-import { HERO_FAMILY_MAP, HERO_VISUALS, getHeroVisualTraits, HeroVisualTraits, HeroFamilyId } from './types';
+import { HeroFamilyId } from './types';
+import { CLAN_VISUAL_PROFILES, HeroSkinVariant, resolveHeroVisualIdentity } from './heroVisualSystem';
 
 const TILE = 40;
 
@@ -83,72 +84,53 @@ const RARITY_SPRITES: Record<string, HeroSpriteConfig> = {
   },
 };
 
-const FAMILY_SPRITES: Record<string, Partial<HeroSpriteConfig>> = {
+const FAMILY_SPRITES: Record<HeroFamilyId, Partial<HeroSpriteConfig>> = {
   'ember-clan': {
-    helmetColor: '#FF6B35',
-    visorColor: '#8B2500',
-    bodyColor: '#E85D04',
+    helmetColor: CLAN_VISUAL_PROFILES['ember-clan'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['ember-clan'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['ember-clan'].secondary,
   },
   'storm-riders': {
-    helmetColor: '#4CC9F0',
-    visorColor: '#023E8A',
-    bodyColor: '#4361EE',
+    helmetColor: CLAN_VISUAL_PROFILES['storm-riders'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['storm-riders'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['storm-riders'].secondary,
   },
   'forge-guard': {
-    helmetColor: '#A8A8A8',
-    visorColor: '#404040',
-    bodyColor: '#6C757D',
+    helmetColor: CLAN_VISUAL_PROFILES['forge-guard'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['forge-guard'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['forge-guard'].secondary,
   },
   'shadow-core': {
-    helmetColor: '#7B2CBF',
-    visorColor: '#240046',
-    bodyColor: '#5A189A',
+    helmetColor: CLAN_VISUAL_PROFILES['shadow-core'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['shadow-core'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['shadow-core'].secondary,
   },
   'arcane-circuit': {
-    helmetColor: '#06D6A0',
-    visorColor: '#004B23',
-    bodyColor: '#2EC4B6',
+    helmetColor: CLAN_VISUAL_PROFILES['arcane-circuit'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['arcane-circuit'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['arcane-circuit'].secondary,
   },
   'wild-pack': {
-    helmetColor: '#70E000',
-    visorColor: '#38B000',
-    bodyColor: '#9EF01A',
+    helmetColor: CLAN_VISUAL_PROFILES['wild-pack'].primary,
+    visorColor: CLAN_VISUAL_PROFILES['wild-pack'].visor,
+    bodyColor: CLAN_VISUAL_PROFILES['wild-pack'].secondary,
   },
 };
 
+interface ResolvedHeroRenderConfig {
+  config: HeroSpriteConfig;
+  family: HeroFamilyId;
+  skin: HeroSkinVariant;
+}
 
-
-
-function getHeroSpriteConfig(rarity: string, heroId?: string): HeroSpriteConfig {
+function getHeroSpriteConfig(rarity: string, heroId?: string, heroName?: string): ResolvedHeroRenderConfig {
   const baseConfig = RARITY_SPRITES[rarity] || RARITY_SPRITES.common;
-  
-  if (!heroId || heroId === 'bestiary-preview') {
-    return baseConfig;
-  }
-  
-  const heroIdLower = heroId.toLowerCase();
-  const heroVisual = HERO_VISUALS[heroIdLower];
-  
-  if (!heroVisual) {
-    const family = HERO_FAMILY_MAP[heroIdLower];
-    const familyConfig = family ? FAMILY_SPRITES[family] : null;
-    if (!familyConfig) {
-      return baseConfig;
-    }
-    return {
-      ...baseConfig,
-      ...familyConfig,
-    };
-  }
-  
-  const family = heroVisual.family;
-  const familyConfig = FAMILY_SPRITES[family];
-  
-  const traits = heroVisual.traits;
-  
+  const identity = resolveHeroVisualIdentity(heroId, heroName);
+  const familyConfig = FAMILY_SPRITES[identity.family] || {};
+
   let aura: string | undefined;
-  if (traits.aura || rarity === 'epic' || rarity === 'legend' || rarity === 'super-legend') {
-    const auraColors: Record<string, string> = {
+  if (identity.traits.aura || rarity === 'epic' || rarity === 'legend' || rarity === 'super-legend') {
+    const auraColors: Record<HeroFamilyId, string> = {
       'ember-clan': 'rgba(255,100,0,0.15)',
       'storm-riders': 'rgba(50,150,255,0.15)',
       'forge-guard': 'rgba(150,150,150,0.15)',
@@ -156,19 +138,31 @@ function getHeroSpriteConfig(rarity: string, heroId?: string): HeroSpriteConfig 
       'arcane-circuit': 'rgba(0,200,150,0.15)',
       'wild-pack': 'rgba(100,200,0,0.15)',
     };
-    aura = auraColors[family] || baseConfig.aura;
+    aura = auraColors[identity.family] || baseConfig.aura;
   }
-  
+
+  const skinAccentByVariant: Record<HeroSkinVariant, string> = {
+    classic: identity.traits.accentColor,
+    scarred: shadeColor(identity.traits.accentColor, -10),
+    elite: shadeColor(identity.traits.accentColor, 8),
+    arcane: shadeColor(identity.traits.accentColor, 14),
+  };
+  const skinAccent = skinAccentByVariant[identity.skin] || identity.traits.accentColor;
+
   return {
-    ...baseConfig,
-    ...familyConfig,
-    aura,
-    hasHorns: traits.helmetStyle === 'horned' || baseConfig.hasHorns,
-    hasCrown: traits.helmetStyle === 'crowned' || baseConfig.hasCrown,
-    hasWings: traits.wings || baseConfig.hasWings,
-    helmetColor: traits.accentColor || familyConfig?.helmetColor || baseConfig.helmetColor,
-    bodyColor: traits.accentColor ? shadeColor(traits.accentColor, -20) : familyConfig?.bodyColor || baseConfig.bodyColor,
-    visorColor: traits.accentColor ? shadeColor(traits.accentColor, -60) : familyConfig?.visorColor || baseConfig.visorColor,
+    family: identity.family,
+    skin: identity.skin,
+    config: {
+      ...baseConfig,
+      ...familyConfig,
+      aura,
+      hasHorns: identity.traits.helmetStyle === 'horned' || baseConfig.hasHorns,
+      hasCrown: identity.traits.helmetStyle === 'crowned' || baseConfig.hasCrown,
+      hasWings: identity.traits.wings || baseConfig.hasWings,
+      helmetColor: skinAccent || familyConfig.helmetColor || baseConfig.helmetColor,
+      bodyColor: skinAccent ? shadeColor(skinAccent, -20) : familyConfig.bodyColor || baseConfig.bodyColor,
+      visorColor: skinAccent ? shadeColor(skinAccent, -60) : familyConfig.visorColor || baseConfig.visorColor,
+    },
   };
 }
 
@@ -179,6 +173,35 @@ function shadeColor(color: string, percent: number): string {
   const G = Math.max(0, Math.min(255, ((num >> 8) & 0x00FF) + amt));
   const B = Math.max(0, Math.min(255, (num & 0x0000FF) + amt));
   return `#${(0x1000000 + R * 0x10000 + G * 0x100 + B).toString(16).slice(1)}`;
+}
+
+function drawSkinPattern(
+  ctx: CanvasRenderingContext2D,
+  skin: HeroSkinVariant,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  accent: string,
+) {
+  switch (skin) {
+    case 'scarred':
+      ctx.fillStyle = shadeColor(accent, -35);
+      ctx.fillRect(x + 1, y + 2, 2, 1);
+      ctx.fillRect(x + width - 4, y + height - 4, 2, 1);
+      break;
+    case 'elite':
+      ctx.fillStyle = shadeColor(accent, 25);
+      ctx.fillRect(x + 1, y + 1, width - 2, 1);
+      break;
+    case 'arcane':
+      ctx.fillStyle = '#C8F7FF';
+      ctx.fillRect(x + width / 2 - 1, y + 1, 2, height - 2);
+      break;
+    default:
+      ctx.fillStyle = 'rgba(255,255,255,0.08)';
+      ctx.fillRect(x + 1, y + 1, width - 2, 1);
+  }
 }
 
 const CLAN_PORTRAIT_STYLES: Record<string, {
@@ -196,16 +219,13 @@ const CLAN_PORTRAIT_STYLES: Record<string, {
   'wild-pack': { helmetShape: 'spiked', visorPattern: 'dual', shoulderPads: true, emblemPattern: 'paw', accentShape: 'stripe' },
 };
 
-function getClanStyle(heroId?: string) {
-  if (!heroId) return CLAN_PORTRAIT_STYLES['ember-clan'];
-  const heroIdLower = heroId.toLowerCase();
-  const family = HERO_FAMILY_MAP[heroIdLower];
-  return family ? (CLAN_PORTRAIT_STYLES[family] || CLAN_PORTRAIT_STYLES['ember-clan']) : CLAN_PORTRAIT_STYLES['ember-clan'];
+function getClanStyle(family: HeroFamilyId) {
+  return CLAN_PORTRAIT_STYLES[family] || CLAN_PORTRAIT_STYLES['ember-clan'];
 }
 
-export function drawHeroPortrait(ctx: CanvasRenderingContext2D, rarity: string, time: number = 0, heroId?: string) {
-  const config = getHeroSpriteConfig(rarity, heroId);
-  const clanStyle = getClanStyle(heroId);
+export function drawHeroPortrait(ctx: CanvasRenderingContext2D, rarity: string, time: number = 0, heroId?: string, heroName?: string) {
+  const { config, family, skin } = getHeroSpriteConfig(rarity, heroId, heroName);
+  const clanStyle = getClanStyle(family);
   const shouldBlink = Math.sin(time / 2000) > 0.93;
   const cx = 20;
   const cy = 20;
@@ -292,6 +312,8 @@ export function drawHeroPortrait(ctx: CanvasRenderingContext2D, rarity: string, 
       ctx.arc(cx, cy + 2, 8, 0, Math.PI * 2);
       ctx.fill();
   }
+
+  drawSkinPattern(ctx, skin, cx - 8, cy - 2, 16, 10, config.helmetColor);
 
   // Clan emblem on helmet
   if (clanStyle.emblemPattern !== 'none') {
@@ -448,12 +470,13 @@ export function drawHeroSprite(
   heroId: string,
   stamina: number,
   maxStamina: number,
+  heroName?: string,
 ) {
   const px = x * TILE;
   const py = y * TILE;
   const cx = px + TILE / 2;
-  const config = getHeroSpriteConfig(rarity, heroId);
-  const clanStyle = getClanStyle(heroId);
+  const { config, family, skin } = getHeroSpriteConfig(rarity, heroId, heroName);
+  const clanStyle = getClanStyle(family);
 
   // Bob animation
   const isMoving = state === 'moving' || state === 'retreating';
@@ -544,6 +567,7 @@ export function drawHeroSprite(
   ctx.fillRect(cx - 9, by + 12, 18, 16 + breathe);
   ctx.fillStyle = config.bodyColor;
   ctx.fillRect(cx - 8, by + 13, 16, 14 + breathe);
+  drawSkinPattern(ctx, skin, cx - 8, by + 13, 16, 14, config.helmetColor);
   // Chest plate highlight
   ctx.fillStyle = 'rgba(255,255,255,0.12)';
   ctx.fillRect(cx - 6, by + 14, 5, 8);

--- a/src/game/heroVisualSystem.ts
+++ b/src/game/heroVisualSystem.ts
@@ -1,0 +1,66 @@
+import { HERO_FAMILIES, HERO_FAMILY_MAP, HERO_VISUALS, HeroFamilyId, HeroVisualTraits, getHeroVisualTraits } from './types';
+
+export type HeroSkinVariant = 'classic' | 'scarred' | 'elite' | 'arcane';
+
+export interface ClanVisualProfile {
+  primary: string;
+  secondary: string;
+  visor: string;
+  motif: 'flame' | 'lightning' | 'shield' | 'eye' | 'circuit' | 'paw';
+}
+
+export const CLAN_VISUAL_PROFILES: Record<HeroFamilyId, ClanVisualProfile> = {
+  'ember-clan': { primary: '#FF6B35', secondary: '#E85D04', visor: '#8B2500', motif: 'flame' },
+  'storm-riders': { primary: '#4CC9F0', secondary: '#4361EE', visor: '#023E8A', motif: 'lightning' },
+  'forge-guard': { primary: '#A8A8A8', secondary: '#6C757D', visor: '#404040', motif: 'shield' },
+  'shadow-core': { primary: '#7B2CBF', secondary: '#5A189A', visor: '#240046', motif: 'eye' },
+  'arcane-circuit': { primary: '#06D6A0', secondary: '#2EC4B6', visor: '#004B23', motif: 'circuit' },
+  'wild-pack': { primary: '#70E000', secondary: '#9EF01A', visor: '#38B000', motif: 'paw' },
+};
+
+interface HeroVisualIdentity {
+  family: HeroFamilyId;
+  traits: HeroVisualTraits;
+  skin: HeroSkinVariant;
+}
+
+function normalizeToken(value?: string): string | undefined {
+  if (!value) return undefined;
+  return value.toLowerCase().replace(/[^a-z]/g, '');
+}
+
+function resolveHeroKey(heroId?: string, heroName?: string): string | undefined {
+  const normalizedId = normalizeToken(heroId);
+  if (normalizedId && HERO_VISUALS[normalizedId]) return normalizedId;
+
+  const firstWord = heroName?.split(/\s+/)[0];
+  const normalizedName = normalizeToken(firstWord);
+  if (normalizedName && HERO_VISUALS[normalizedName]) return normalizedName;
+
+  return normalizedId;
+}
+
+function hashSeed(value: string): number {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i++) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return Math.abs(hash >>> 0);
+}
+
+const SKIN_VARIANTS: HeroSkinVariant[] = ['classic', 'scarred', 'elite', 'arcane'];
+
+export function resolveHeroVisualIdentity(heroId?: string, heroName?: string): HeroVisualIdentity {
+  const heroKey = resolveHeroKey(heroId, heroName);
+
+  const baseFamily = heroKey ? HERO_FAMILY_MAP[heroKey] : undefined;
+  const seed = hashSeed(`${heroId ?? 'legacy'}::${heroName ?? heroKey ?? 'unknown'}`);
+  const fallbackFamily = HERO_FAMILIES[seed % HERO_FAMILIES.length]?.id ?? 'ember-clan';
+  const family = (baseFamily ?? fallbackFamily) as HeroFamilyId;
+
+  const traits = heroKey ? getHeroVisualTraits(heroKey) : { helmetStyle: 'standard', cape: false, wings: false, aura: false, accentColor: CLAN_VISUAL_PROFILES[family].primary };
+  const skin = SKIN_VARIANTS[seed % SKIN_VARIANTS.length] ?? 'classic';
+
+  return { family, traits, skin };
+}

--- a/src/pages/Bestiary.tsx
+++ b/src/pages/Bestiary.tsx
@@ -84,7 +84,7 @@ const BomberCard: React.FC<{ bomber: BestiaryBomber }> = ({ bomber }) => {
           <div className="relative">
             <div className="w-12 h-12 rounded-lg bg-muted border border-border flex items-center justify-center shrink-0 overflow-hidden">
               {bomber.rarity ? (
-                <HeroAvatar heroId={bomber.id} rarity={bomber.rarity} size={44} />
+                <HeroAvatar heroId={bomber.id} heroName={bomber.name} rarity={bomber.rarity} size={44} />
               ) : (
                 <AlertTriangle size={14} className="text-muted-foreground" />
               )}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1558,7 +1558,7 @@ const Index = () => {
                       >
                         {hero ? (
                           <>
-                            <HeroAvatar heroId={hero.id} rarity={hero.rarity} size={32} />
+                            <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={32} />
                             <p className="font-pixel text-[7px] text-foreground mt-1 truncate max-w-[60px]">{hero.name.split(' ')[0]}</p>
                             <p className="text-[7px] mt-0.5" style={{ color: `hsl(var(--game-rarity-${hero.rarity}))` }}>
                               {RARITY_CONFIG[hero.rarity].label}


### PR DESCRIPTION
## Résumé
- introduit un système de visuels héros unifié (`heroVisualSystem`) qui résout clan + traits + skin à partir de `hero.id` et/ou `hero.name`
- applique des variantes de skin déterministes (classic/scarred/elite/arcane) sur portrait et sprite pour différencier les héros d'un même clan
- conserve la lisibilité de rareté (palette de base, aura et marqueurs rarity inchangés/prioritaires)
- ajoute un fallback safe pour anciens héros (noms historiques, ids legacy, puis fallback de clan déterministe si inconnu)
- propage `heroName` dans les renderers (`HeroAvatar`, `GameGrid`, écrans bestiary/index/cards/summon)

## Tests
- `npm ci`
- `npm run build` ✅

## Notes visuelles / captures
- Pas de capture jointe dans cette passe CLI.
- Vérification manuelle recommandée sur: collection, summon, bestiary, et rendu en map pour observer les skins par clan + variation intra-clan.
