### PR TITLE
fix(ui-auto-repair): align radar findings contract and dry-run --report output

### DIFF
--- a/docs/ui-auto-repair-loop.md
+++ b/docs/ui-auto-repair-loop.md
@@ -13,7 +13,7 @@ MVP pragmatique pour transformer un rapport **UI radar** (JSON) en plan de corre
 ```json
 {
   "generatedAt": "2026-03-15T22:00:00Z",
-  "issues": [
+  "findings": [
     {
       "id": 201,
       "title": "CTA mobile tronqué",
@@ -30,13 +30,15 @@ MVP pragmatique pour transformer un rapport **UI radar** (JSON) en plan de corre
 }
 ```
 
+> Le planner lit en priorité `findings` (contrat radar courant) et reste compatible avec `issues` (ancien format).
+>
 > Le loop n'applique **pas** de patch libre: uniquement `replace_text` dans `src/**/*.ts(x)|css`.
 
 ## Scripts npm
 
 - `npm run ui:repair:plan -- --radar <file> [--baseline <file>] [--out <file>]`
-- `npm run ui:repair:run -- --plan <file> [--summary <file>] [--max-files 4] [--max-diff-lines 200]`
-- `npm run ui:repair:dry -- --plan <file>`
+- `npm run ui:repair:run -- --plan <file> [--summary <file>|--report <file>] [--max-files 4] [--max-diff-lines 200]`
+- `npm run ui:repair:dry -- --plan <file> [--report <file>]`
 
 ## Exécution locale
 

--- a/scripts/ui-auto-repair/plan-from-radar.mjs
+++ b/scripts/ui-auto-repair/plan-from-radar.mjs
@@ -53,12 +53,18 @@ function loadJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
 }
 
+function getRadarItems(radarReport) {
+  if (Array.isArray(radarReport?.findings)) return radarReport.findings;
+  if (Array.isArray(radarReport?.issues)) return radarReport.issues;
+  return [];
+}
+
 function buildPlan(radarReport, baselineReport) {
-  const issues = Array.isArray(radarReport?.issues) ? radarReport.issues : [];
+  const items = getRadarItems(radarReport);
   const actions = [];
   const skipped = [];
 
-  for (const issue of issues) {
+  for (const issue of items) {
     const severity = toSeverity(issue.severity || issue.priority);
     const eligibility = isAutoFixable(issue);
 
@@ -91,7 +97,7 @@ function buildPlan(radarReport, baselineReport) {
     radarMeta: {
       reportPath: radarReport?.meta?.reportPath || null,
       reportGeneratedAt: radarReport?.generatedAt || null,
-      issuesTotal: issues.length,
+      issuesTotal: items.length,
     },
     baselineMeta: baselineReport
       ? {

--- a/scripts/ui-auto-repair/run-loop.mjs
+++ b/scripts/ui-auto-repair/run-loop.mjs
@@ -67,7 +67,7 @@ function rollbackFiles(files) {
 function main() {
   const args = parseArgs(process.argv);
   const planPath = args.plan || 'artifacts/ui-auto-repair/repair-plan.json';
-  const summaryPath = args.summary || 'artifacts/ui-auto-repair/repair-summary.json';
+  const summaryPath = args.report || args.summary || 'artifacts/ui-auto-repair/repair-summary.json';
   const dryRun = String(args['dry-run'] || 'false') === 'true';
   const maxFiles = Number(args['max-files'] || 4);
   const maxDiffLines = Number(args['max-diff-lines'] || 200);

--- a/src/test/uiAutoRepairScripts.test.ts
+++ b/src/test/uiAutoRepairScripts.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const repoRoot = process.cwd();
+const planScript = path.join(repoRoot, 'scripts/ui-auto-repair/plan-from-radar.mjs');
+const runLoopScript = path.join(repoRoot, 'scripts/ui-auto-repair/run-loop.mjs');
+
+function mkTmpDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'ui-auto-repair-'));
+}
+
+describe('ui auto-repair scripts', () => {
+  test('plan-from-radar lit findings', () => {
+    const dir = mkTmpDir();
+    const radarPath = path.join(dir, 'radar.json');
+    const outPath = path.join(dir, 'plan.json');
+
+    fs.writeFileSync(
+      radarPath,
+      JSON.stringify({
+        findings: [
+          {
+            id: 1,
+            title: 'Fix CTA',
+            severity: 'P1',
+            fix: {
+              kind: 'replace_text',
+              file: 'src/pages/Landing.tsx',
+              find: 'old',
+              replace: 'new',
+            },
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    execFileSync('node', [planScript, '--radar', radarPath, '--out', outPath], { cwd: repoRoot });
+
+    const plan = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    expect(plan.radarMeta.issuesTotal).toBe(1);
+    expect(plan.actions).toHaveLength(1);
+  });
+
+  test('plan-from-radar reste compatible avec issues', () => {
+    const dir = mkTmpDir();
+    const radarPath = path.join(dir, 'radar-legacy.json');
+    const outPath = path.join(dir, 'plan-legacy.json');
+
+    fs.writeFileSync(
+      radarPath,
+      JSON.stringify({
+        issues: [
+          {
+            id: 2,
+            title: 'Legacy format issue',
+            severity: 'P2',
+            fix: {
+              kind: 'replace_text',
+              file: 'src/pages/Index.tsx',
+              find: 'foo',
+              replace: 'bar',
+            },
+          },
+        ],
+      }),
+      'utf8',
+    );
+
+    execFileSync('node', [planScript, '--radar', radarPath, '--out', outPath], { cwd: repoRoot });
+
+    const plan = JSON.parse(fs.readFileSync(outPath, 'utf8'));
+    expect(plan.radarMeta.issuesTotal).toBe(1);
+    expect(plan.actions).toHaveLength(1);
+  });
+
+  test('run-loop dry-run respecte --report', () => {
+    const dir = mkTmpDir();
+    const planPath = path.join(dir, 'plan.json');
+    const reportPath = path.join(dir, 'custom-report.json');
+
+    fs.writeFileSync(
+      planPath,
+      JSON.stringify({
+        actions: [
+          {
+            issueId: 3,
+            fix: {
+              kind: 'replace_text',
+              file: 'src/pages/Landing.tsx',
+              find: 'foo',
+              replace: 'bar',
+            },
+          },
+        ],
+        skipped: [],
+      }),
+      'utf8',
+    );
+
+    execFileSync('node', [runLoopScript, '--dry-run=true', '--plan', planPath, '--report', reportPath], {
+      cwd: repoRoot,
+    });
+
+    expect(fs.existsSync(reportPath)).toBe(true);
+    const summary = JSON.parse(fs.readFileSync(reportPath, 'utf8'));
+    expect(summary.result.dryRun).toBe(true);
+    expect(summary.planPath).toBe(planPath);
+  });
+});


### PR DESCRIPTION
## Summary
- align `plan-from-radar` with the current radar contract by reading `findings` first
- keep backward compatibility with legacy `issues` payloads
- make `run-loop` honor `--report` (alias of `--summary`) so `ui:repair:dry` can write to a custom output path
- update docs and add targeted tests for both behaviors

## Validation
- `npm ci`
- `npm run build`
- `npm run test`
- `npm run ui:repair:plan -- --radar reports/ui-radar/ui-radar-report.json --out artifacts/ui-auto-repair/repair-plan.issue138.json`
- `npm run ui:repair:dry -- --plan artifacts/ui-auto-repair/repair-plan.issue138.json --report artifacts/ui-auto-repair/repair-summary.issue138.json`

Closes #138.
