### PR TITLE
fix: replace fragile clickText with stable data-testid selectors (Fixes #137)

### DIFF
--- a/scripts/ui-qa-radar.mjs
+++ b/scripts/ui-qa-radar.mjs
@@ -19,14 +19,14 @@ const scenarios = [
     label: 'Game: Fusion tab',
     path: '/game',
     expectedTexts: ['Fusion'],
-    actions: [{ type: 'clickText', text: 'Fusion' }],
+    actions: [{ type: 'clickTestId', testId: 'tab-fusion' }],
   },
   {
     key: 'game-heroes',
     label: 'Game: Heroes tab',
     path: '/game',
     expectedTexts: ['Héros'],
-    actions: [{ type: 'clickText', text: 'Héros' }],
+    actions: [{ type: 'clickTestId', testId: 'tab-heroes' }],
   },
   { key: 'bestiary', label: 'Wiki Bestiary', path: '/wiki/bestiaire', expectedTexts: ['Bestiaire'] },
   { key: 'summon', label: 'Summon / Fusion screen', path: '/summon', expectedTexts: ['Invocation', 'Invoquer'] },
@@ -35,7 +35,7 @@ const scenarios = [
     label: 'Summon: Fusion tab state',
     path: '/summon',
     expectedTexts: ['Fusion'],
-    actions: [{ type: 'clickText', text: 'Fusion' }],
+    actions: [{ type: 'clickTestId', testId: 'tab-summon' }],
   },
 ];
 
@@ -84,6 +84,15 @@ async function runAction(page, action) {
       return { ok: true };
     }
     return { ok: false, reason: `text '${action.text}' not found` };
+  }
+  if (action.type === 'clickTestId') {
+    const locator = page.getByTestId(action.testId);
+    if (await locator.count()) {
+      await locator.click({ timeout: 3000 }).catch(() => {});
+      await page.waitForTimeout(400);
+      return { ok: true };
+    }
+    return { ok: false, reason: `testId '${action.testId}' not found` };
   }
   return { ok: false, reason: `unknown action ${action.type}` };
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1439,16 +1439,17 @@ const Index = () => {
       {!isInBattle && (
         <nav className="sticky top-[49px] sm:top-[49px] z-30 bg-card/90 backdrop-blur border-b border-border px-1 sm:px-2 py-1.5 flex gap-1 overflow-x-auto">
           {[
-            { id: 'hub' as Screen, label: 'Hub', icon: <Home size={14} /> },
-            { id: 'story' as Screen, label: 'Histoire', icon: <BookOpen size={14} /> },
-            { id: 'heroes' as Screen, label: 'Héros', icon: <Users size={14} /> },
-            { id: 'codex' as Screen, label: 'Codex', icon: <BookOpen size={14} /> },
-            { id: 'fusion' as Screen, label: 'Fusion', icon: <Hammer size={14} /> },
-            { id: 'summon' as Screen, label: 'Invoquer', icon: <Sparkles size={14} /> },
-            { id: 'achievements' as Screen, label: 'Succès', icon: <Trophy size={14} /> },
+            { id: 'hub' as Screen, label: 'Hub', icon: <Home size={14} />, testId: 'tab-hub' },
+            { id: 'story' as Screen, label: 'Histoire', icon: <BookOpen size={14} />, testId: 'tab-story' },
+            { id: 'heroes' as Screen, label: 'Héros', icon: <Users size={14} />, testId: 'tab-heroes' },
+            { id: 'codex' as Screen, label: 'Codex', icon: <BookOpen size={14} />, testId: 'tab-codex' },
+            { id: 'fusion' as Screen, label: 'Fusion', icon: <Hammer size={14} />, testId: 'tab-fusion' },
+            { id: 'summon' as Screen, label: 'Invoquer', icon: <Sparkles size={14} />, testId: 'tab-summon' },
+            { id: 'achievements' as Screen, label: 'Succès', icon: <Trophy size={14} />, testId: 'tab-achievements' },
           ].map(tab => (
             <button
               key={tab.id}
+              data-testid={tab.testId}
               onClick={() => {
                 if (tab.id === 'summon') navigate('/summon');
                 else setScreen(tab.id);


### PR DESCRIPTION
## Summary
- Add `data-testid` attributes to all tab navigation buttons in Index.tsx
- Add `clickTestId` action type in UI radar script for stable selectors
- Replace all `clickText` usages in radar scenarios with `clickTestId`

## Changes
- `src/pages/Index.tsx`: Added `data-testid` to tab buttons (tab-hub, tab-story, tab-heroes, tab-codex, tab-fusion, tab-summon, tab-achievements)
- `scripts/ui-qa-radar.mjs`: Added `clickTestId` action handler

## Validation
- npm ci ✓
- npm run build ✓
- npm run test ✓ (7 tests passed)

Fixes #137