### PR TITLE
feat(hero-identity): carte d'identité héros avec stats de progression

### DIFF
--- a/src/components/HeroUpgradeModal.tsx
+++ b/src/components/HeroUpgradeModal.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PixelIcon from '@/components/PixelIcon';
+import HeroAvatar from '@/components/HeroAvatar';
 import { Hero, RARITY_CONFIG, MAX_LEVEL_BY_RARITY } from '@/game/types';
 import { getStatsAtLevel, getAscensionCost, MAX_STARS, countDuplicates, getXpProgress, getMaxLevel } from '@/game/upgradeSystem';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Progress } from '@/components/ui/progress';
-import { Swords, Zap, Target, Bomb, Battery, Clover, Shield, Star, ArrowUp, Coins, TrendingUp, Lock, Sparkles, Users } from 'lucide-react';
+import { Swords, Zap, Target, Bomb, Battery, Clover, Shield, Star, ArrowUp, Coins, TrendingUp, Lock, Sparkles, Users, User, Calendar, Trophy, Gem } from 'lucide-react';
 
 interface HeroUpgradeModalProps {
   hero: Hero | null;
@@ -27,6 +28,8 @@ const STAT_META: Record<string, { icon: React.ReactNode; label: string }> = {
 };
 
 const HeroUpgradeModal: React.FC<HeroUpgradeModalProps> = ({ hero, coins, allHeroes, onClose, onUpgrade, onAscend }) => {
+  const [activeTab, setActiveTab] = useState<'upgrade' | 'identity'>('upgrade');
+
   if (!hero) return null;
 
   const config = RARITY_CONFIG[hero.rarity];
@@ -35,24 +38,27 @@ const HeroUpgradeModal: React.FC<HeroUpgradeModalProps> = ({ hero, coins, allHer
   const isMaxStars = hero.stars >= MAX_STARS;
   const xpProgress = getXpProgress(hero);
 
-  // For level up: show next level stats
   const nextLevelStats = isMaxLevel ? null : getStatsAtLevel(hero.rarity, hero.level + 1, hero.stars);
-
-  // For ascension: show next star stats (only at max level)
   const ascensionInfo = isMaxLevel && !isMaxStars ? getAscensionCost(hero.stars) : null;
   const nextStarStats = ascensionInfo ? getStatsAtLevel(hero.rarity, hero.level, hero.stars + 1) : null;
   const duplicates = allHeroes ? countDuplicates(allHeroes, hero.id, hero.rarity) : 0;
   const canAscend = ascensionInfo ? coins >= ascensionInfo.cost && duplicates >= ascensionInfo.duplicates : false;
-
-  // Choose which "next stats" to display
   const nextStats = nextLevelStats || nextStarStats;
-
   const staPct = (hero.currentStamina / hero.maxStamina) * 100;
+
+  const obtainedDate = new Date(hero.progressionStats.obtainedAt);
+  const formattedDate = obtainedDate.toLocaleDateString('fr-FR', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+  const winRate = hero.progressionStats.battlesPlayed > 0
+    ? Math.round((hero.progressionStats.victories / hero.progressionStats.battlesPlayed) * 100)
+    : 0;
 
   return (
     <Dialog open={!!hero} onOpenChange={() => onClose()}>
-      <DialogContent className="pixel-border bg-card border-border max-w-md p-0 overflow-hidden rounded-none sm:rounded-lg max-h-[90vh]">
-        {/* Header with rarity gradient */}
+      <DialogContent className="pixel-border bg-card border-border max-w-md p-0 overflow-hidden rounded-none sm:rounded-lg max-h-[90vh] overflow-y-auto">
         <div
           className="p-5 pb-3 relative"
           style={{
@@ -89,141 +95,229 @@ const HeroUpgradeModal: React.FC<HeroUpgradeModalProps> = ({ hero, coins, allHer
           </DialogHeader>
         </div>
 
+        <div className="px-5 pb-3">
+          <div className="flex border-b border-border">
+            <button
+              onClick={() => setActiveTab('upgrade')}
+              className={`flex-1 py-2 text-[10px] font-pixel transition-colors ${
+                activeTab === 'upgrade'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Améliorer
+            </button>
+            <button
+              onClick={() => setActiveTab('identity')}
+              className={`flex-1 py-2 text-[10px] font-pixel transition-colors ${
+                activeTab === 'identity'
+                  ? 'text-primary border-b-2 border-primary'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              Carte d'identité
+            </button>
+          </div>
+        </div>
+
         <div className="px-5 pb-5 space-y-4">
-          {/* Stamina bar */}
-          <div>
-            <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
-              <span className="flex items-center gap-1"><Battery size={10} /> Endurance</span>
-              <span>{Math.floor(hero.currentStamina)}/{hero.maxStamina}</span>
-            </div>
-            <Progress value={staPct} className="h-2" />
-          </div>
-
-          {/* Stats comparison */}
-          <div className="space-y-1.5">
-            <p className="font-pixel text-[9px] text-muted-foreground flex items-center gap-1">
-              <TrendingUp size={10} /> STATISTIQUES
-            </p>
-            {Object.entries(hero.stats).map(([key, val]) => {
-              const meta = STAT_META[key];
-              const nextVal = nextStats ? nextStats[key as keyof typeof nextStats] : null;
-              const diff = nextVal ? nextVal - val : 0;
-              return (
-                <div key={key} className="flex items-center gap-2 text-[11px]">
-                  <div className="flex items-center gap-1.5 w-24 text-muted-foreground">
-                    {meta.icon}
-                    <span>{meta.label}</span>
-                  </div>
-                  <div className="flex-1 flex items-center gap-2">
-                    <span className="font-bold text-foreground w-8 text-right">{val}</span>
-                    {nextVal !== null && diff > 0 && (
-                      <>
-                        <ArrowUp size={10} className={nextStarStats ? 'text-game-gold' : 'text-game-energy-green'} />
-                        <span className={`font-bold ${nextStarStats ? 'text-game-gold' : 'text-game-energy-green'}`}>{nextVal}</span>
-                        <span className={`text-[9px] ${nextStarStats ? 'text-game-gold' : 'text-game-energy-green'}`}>(+{key === 'lck' ? diff + '%' : diff})</span>
-                      </>
-                    )}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          {/* Skills */}
-          {hero.skills.length > 0 && (
-            <div className="space-y-1">
-              <p className="font-pixel text-[9px] text-muted-foreground flex items-center gap-1">
-                <Zap size={10} /> COMPÉTENCES
-              </p>
-              {hero.skills.map((skill, i) => (
-                <div key={i} className="bg-muted rounded px-2 py-1.5 text-[10px]">
-                  <p className="text-foreground font-medium flex items-center gap-1">
-                    <Zap size={9} className="text-accent" /> {skill.name}
-                  </p>
-                  <p className="text-muted-foreground mt-0.5">{skill.description}</p>
-                </div>
-              ))}
-            </div>
-          )}
-
-          {/* Action buttons */}
-          <div className="pt-2 border-t border-border space-y-2">
-            {/* XP Progress */}
-            {!isMaxLevel && (
-              <div className="bg-muted/50 rounded p-3 space-y-2">
-                <p className="font-pixel text-[9px] text-game-xp-blue flex items-center gap-1">
-                  <Zap size={12} /> PROGRESSION XP
-                </p>
-                <div className="space-y-1">
-                  <Progress value={xpProgress.percentage} className="h-3" />
-                  <p className="text-[10px] text-muted-foreground text-center">
-                    {xpProgress.current.toLocaleString()} / {xpProgress.required.toLocaleString()} XP
-                  </p>
-                </div>
-                <p className="text-[9px] text-muted-foreground">
-                  Joue pour gagner de l'XP! Pose des bombes, détruis des blocs et ouvre des coffres.
-                </p>
-              </div>
-            )}
-
-            {/* Ascension */}
-            {isMaxLevel && !isMaxStars && ascensionInfo && (
-              <div className="space-y-2">
-                <div className="bg-muted/50 rounded p-3 space-y-2">
-                  <p className="font-pixel text-[9px] text-game-gold flex items-center gap-1">
-                    <Sparkles size={12} /> ASCENSION — ÉTOILE {hero.stars + 1}/{MAX_STARS}
-                  </p>
-                  <p className="text-[10px] text-muted-foreground">
-                    L'ascension augmente toutes les stats de +{((hero.stars + 1) * 20)}% et renforce ton héros au-delà du niveau max.
-                  </p>
-                  <div className="flex items-center gap-4 text-[10px]">
-                    <div className="flex items-center gap-1">
-                      <Coins size={12} className="text-game-gold" />
-                      <span className={coins >= ascensionInfo.cost ? 'text-game-energy-green' : 'text-destructive'}>
-                        {ascensionInfo.cost.toLocaleString()} BC
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <Users size={12} className="text-primary" />
-                      <span className={duplicates >= ascensionInfo.duplicates ? 'text-game-energy-green' : 'text-destructive'}>
-                        {duplicates}/{ascensionInfo.duplicates} doublons {config.label}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-                <Button
-                  onClick={() => onAscend?.(hero.id)}
-                  disabled={!canAscend}
-                  className="w-full font-pixel text-[10px] gap-2 bg-game-gold/90 hover:bg-game-gold text-background"
-                  variant="default"
+          {activeTab === 'identity' ? (
+            <div className="space-y-5">
+              <div className="flex flex-col items-center">
+                <div
+                  className="w-20 h-20 rounded-xl flex items-center justify-center mb-3"
+                  style={{
+                    boxShadow: `0 0 20px hsl(var(--game-rarity-${hero.rarity}) / 0.4)`,
+                    background: `linear-gradient(135deg, hsl(var(--game-rarity-${hero.rarity}) / 0.2) 0%, hsl(var(--game-rarity-${hero.rarity}) / 0.05) 100%)`,
+                  }}
                 >
-                  {canAscend ? (
-                    <>
-                      <Sparkles size={14} />
-                      ASCENSION ★{hero.stars + 1}
-                    </>
-                  ) : (
-                    <>
-                      <Lock size={14} />
-                      RESSOURCES INSUFFISANTES
-                    </>
-                  )}
-                </Button>
+                  <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={80} />
+                </div>
+                <h3 className="font-pixel text-xs text-foreground">{hero.name}</h3>
+                <span
+                  className="text-[10px] font-pixel mt-1"
+                  style={{ color: `hsl(var(--game-rarity-${hero.rarity}))` }}
+                >
+                  {config.label}
+                </span>
               </div>
-            )}
 
-            {/* Fully maxed */}
-            {isMaxLevel && isMaxStars && (
-              <div className="text-center py-3">
-                <p className="font-pixel text-[10px] text-game-gold flex items-center justify-center gap-1">
-                  <Sparkles size={14} className="fill-current" />
-                  HÉROS MAXIMUM ★★★
-                  <Sparkles size={14} className="fill-current" />
-                </p>
-                <p className="text-[9px] text-muted-foreground mt-1">Niveau {maxLevel} • Ascension complète • Prêt pour fusion</p>
+              <div className="bg-muted/30 rounded-lg p-3 space-y-2">
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="flex items-center gap-2 text-muted-foreground">
+                    <User size={12} /> ID Unique
+                  </span>
+                  <span className="font-mono text-foreground/80 text-[9px]">{hero.id}</span>
+                </div>
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="flex items-center gap-2 text-muted-foreground">
+                    <Calendar size={12} /> Obtenu le
+                  </span>
+                  <span className="text-foreground">{formattedDate}</span>
+                </div>
               </div>
-            )}
-          </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="bg-muted/30 rounded-lg p-3 flex flex-col items-center">
+                  <Coins size={16} className="text-game-gold mb-1" />
+                  <span className="text-lg font-bold text-foreground">{hero.progressionStats.chestsOpened}</span>
+                  <span className="text-[9px] text-muted-foreground text-center">Coffres ouverts</span>
+                </div>
+                <div className="bg-muted/30 rounded-lg p-3 flex flex-col items-center">
+                  <Swords size={16} className="text-destructive mb-1" />
+                  <span className="text-lg font-bold text-foreground">{hero.progressionStats.totalDamageDealt.toLocaleString('fr-FR')}</span>
+                  <span className="text-[9px] text-muted-foreground text-center">Dégâts infligés</span>
+                </div>
+                <div className="bg-muted/30 rounded-lg p-3 flex flex-col items-center">
+                  <Trophy size={16} className="text-game-energy-green mb-1" />
+                  <span className="text-lg font-bold text-foreground">{hero.progressionStats.battlesPlayed}</span>
+                  <span className="text-[9px] text-muted-foreground text-center">Combats joués</span>
+                </div>
+                <div className="bg-muted/30 rounded-lg p-3 flex flex-col items-center">
+                  <Sparkles size={16} className="text-yellow-500 mb-1" />
+                  <span className="text-lg font-bold text-foreground">{hero.progressionStats.victories}</span>
+                  <span className="text-[9px] text-muted-foreground text-center">Victoires ({winRate}%)</span>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-center gap-2 pt-2">
+                <Gem size={14} className="text-accent" />
+                <span className="text-[10px] text-muted-foreground">
+                  Héros collecté le {formattedDate}
+                </span>
+              </div>
+            </div>
+          ) : (
+            <>
+              <div>
+                <div className="flex items-center justify-between text-[10px] text-muted-foreground mb-1">
+                  <span className="flex items-center gap-1"><Battery size={10} /> Endurance</span>
+                  <span>{Math.floor(hero.currentStamina)}/{hero.maxStamina}</span>
+                </div>
+                <Progress value={staPct} className="h-2" />
+              </div>
+
+              <div className="space-y-1.5">
+                <p className="font-pixel text-[9px] text-muted-foreground flex items-center gap-1">
+                  <TrendingUp size={10} /> STATISTIQUES
+                </p>
+                {Object.entries(hero.stats).map(([key, val]) => {
+                  const meta = STAT_META[key];
+                  const nextVal = nextStats ? nextStats[key as keyof typeof nextStats] : null;
+                  const diff = nextVal ? nextVal - val : 0;
+                  return (
+                    <div key={key} className="flex items-center gap-2 text-[11px]">
+                      <div className="flex items-center gap-1.5 w-24 text-muted-foreground">
+                        {meta.icon}
+                        <span>{meta.label}</span>
+                      </div>
+                      <div className="flex-1 flex items-center gap-2">
+                        <span className="font-bold text-foreground w-8 text-right">{val}</span>
+                        {nextVal !== null && diff > 0 && (
+                          <>
+                            <ArrowUp size={10} className={nextStarStats ? 'text-game-gold' : 'text-game-energy-green'} />
+                            <span className={`font-bold ${nextStarStats ? 'text-game-gold' : 'text-game-energy-green'}`}>{nextVal}</span>
+                            <span className={`text-[9px] ${nextStarStats ? 'text-game-gold' : 'text-game-energy-green'}`}>(+{key === 'lck' ? diff + '%' : diff})</span>
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {hero.skills.length > 0 && (
+                <div className="space-y-1">
+                  <p className="font-pixel text-[9px] text-muted-foreground flex items-center gap-1">
+                    <Zap size={10} /> COMPÉTENCES
+                  </p>
+                  {hero.skills.map((skill, i) => (
+                    <div key={i} className="bg-muted rounded px-2 py-1.5 text-[10px]">
+                      <p className="text-foreground font-medium flex items-center gap-1">
+                        <Zap size={9} className="text-accent" /> {skill.name}
+                      </p>
+                      <p className="text-muted-foreground mt-0.5">{skill.description}</p>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="pt-2 border-t border-border space-y-2">
+                {!isMaxLevel && (
+                  <div className="bg-muted/50 rounded p-3 space-y-2">
+                    <p className="font-pixel text-[9px] text-game-xp-blue flex items-center gap-1">
+                      <Zap size={12} /> PROGRESSION XP
+                    </p>
+                    <div className="space-y-1">
+                      <Progress value={xpProgress.percentage} className="h-3" />
+                      <p className="text-[10px] text-muted-foreground text-center">
+                        {xpProgress.current.toLocaleString()} / {xpProgress.required.toLocaleString()} XP
+                      </p>
+                    </div>
+                    <p className="text-[9px] text-muted-foreground">
+                      Joue pour gagner de l'XP! Pose des bombes, détruis des blocs et ouvre des coffres.
+                    </p>
+                  </div>
+                )}
+
+                {isMaxLevel && !isMaxStars && ascensionInfo && (
+                  <div className="space-y-2">
+                    <div className="bg-muted/50 rounded p-3 space-y-2">
+                      <p className="font-pixel text-[9px] text-game-gold flex items-center gap-1">
+                        <Sparkles size={12} /> ASCENSION — ÉTOILE {hero.stars + 1}/{MAX_STARS}
+                      </p>
+                      <p className="text-[10px] text-muted-foreground">
+                        L'ascension augmente toutes les stats de +{((hero.stars + 1) * 20)}% et renforce ton héros au-delà du niveau max.
+                      </p>
+                      <div className="flex items-center gap-4 text-[10px]">
+                        <div className="flex items-center gap-1">
+                          <Coins size={12} className="text-game-gold" />
+                          <span className={coins >= ascensionInfo.cost ? 'text-game-energy-green' : 'text-destructive'}>
+                            {ascensionInfo.cost.toLocaleString()} BC
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-1">
+                          <Users size={12} className="text-primary" />
+                          <span className={duplicates >= ascensionInfo.duplicates ? 'text-game-energy-green' : 'text-destructive'}>
+                            {duplicates}/{ascensionInfo.duplicates} doublons {config.label}
+                          </span>
+                        </div>
+                      </div>
+                    </div>
+                    <Button
+                      onClick={() => onAscend?.(hero.id)}
+                      disabled={!canAscend}
+                      className="w-full font-pixel text-[10px] gap-2 bg-game-gold/90 hover:bg-game-gold text-background"
+                      variant="default"
+                    >
+                      {canAscend ? (
+                        <>
+                          <Sparkles size={14} />
+                          ASCENSION ★{hero.stars + 1}
+                        </>
+                      ) : (
+                        <>
+                          <Lock size={14} />
+                          RESSOURCES INSUFFISANTES
+                        </>
+                      )}
+                    </Button>
+                  </div>
+                )}
+
+                {isMaxLevel && isMaxStars && (
+                  <div className="text-center py-3">
+                    <p className="font-pixel text-[10px] text-game-gold flex items-center justify-center gap-1">
+                      <Sparkles size={14} className="fill-current" />
+                      HÉROS MAXIMUM ★★★
+                      <Sparkles size={14} className="fill-current" />
+                    </p>
+                    <p className="text-[9px] text-muted-foreground mt-1">Niveau {maxLevel} • Ascension complète • Prêt pour fusion</p>
+                  </div>
+                )}
+              </div>
+            </>
+          )}
         </div>
       </DialogContent>
     </Dialog>

--- a/src/game/enemyAI.ts
+++ b/src/game/enemyAI.ts
@@ -309,37 +309,42 @@ export function tickBoss(
 export function damageEnemiesFromExplosion(
   enemies: Enemy[],
   explosionTiles: { x: number; y: number }[],
-  power: number
-): { enemies: Enemy[]; kills: number } {
+  power: number,
+  heroId?: string
+): { enemies: Enemy[]; kills: number; totalDamage: number } {
   let kills = 0;
+  let totalDamage = 0;
   const updated = enemies.map(e => {
     const ex = Math.round(e.position.x);
     const ey = Math.round(e.position.y);
     if (explosionTiles.some(t => t.x === ex && t.y === ey)) {
+      const damage = Math.min(e.hp, power);
+      totalDamage += damage;
       const ne = { ...e, hp: e.hp - power, stunTimer: 0.5 };
       if (ne.hp <= 0) kills++;
       return ne;
     }
     return e;
   });
-  return { enemies: updated, kills };
+  return { enemies: updated, kills, totalDamage };
 }
 
 export function damageBossFromExplosion(
   boss: Boss,
   explosionTiles: { x: number; y: number }[],
   power: number
-): Boss {
-  if (boss.hp <= 0) return boss;
+): { boss: Boss; damageDealt: number } {
+  if (boss.hp <= 0) return { boss, damageDealt: 0 };
   const bx = Math.round(boss.position.x);
   const by = Math.round(boss.position.y);
   if (explosionTiles.some(t => t.x === bx && t.y === by)) {
     if (boss.invincible) {
-      return { ...boss, stunTimer: 0.2 }; // visual feedback only
+      return { boss: { ...boss, stunTimer: 0.2 }, damageDealt: 0 }; // visual feedback only
     }
-    return { ...boss, hp: Math.max(0, boss.hp - power), stunTimer: 0.8 };
+    const damageDealt = Math.min(boss.hp, power);
+    return { boss: { ...boss, hp: Math.max(0, boss.hp - power), stunTimer: 0.8 }, damageDealt };
   }
-  return boss;
+  return { boss, damageDealt: 0 };
 }
 
 export function checkEnemyHeroCollision(

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -426,8 +426,17 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
           eventLog.push(`Coffre ${chest.tier} ouvert! +${chest.reward} BC`);
           if (bomb.heroId && bomb.team === 'heroes') {
             const heroIdx = heroes.findIndex(h => h.id === bomb.heroId);
-            if (heroIdx >= 0 && heroes[heroIdx].level < getMaxLevel(heroes[heroIdx].rarity)) {
-              heroes[heroIdx] = addXp(heroes[heroIdx], XP_REWARDS.chestOpened);
+            if (heroIdx >= 0) {
+              if (heroes[heroIdx].level < getMaxLevel(heroes[heroIdx].rarity)) {
+                heroes[heroIdx] = addXp(heroes[heroIdx], XP_REWARDS.chestOpened);
+              }
+              heroes[heroIdx] = {
+                ...heroes[heroIdx],
+                progressionStats: {
+                  ...heroes[heroIdx].progressionStats,
+                  chestsOpened: heroes[heroIdx].progressionStats.chestsOpened + 1,
+                },
+              };
             }
           }
         }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -495,7 +495,7 @@ const Index = () => {
             SFX.explosion();
             if (exp.team === 'heroes') {
               const heroPower = Math.max(...state.heroes.map(h => h.stats.pwr), 1);
-              const { enemies: updatedEnemies, kills } = damageEnemiesFromExplosion(enemies, exp.tiles, heroPower);
+              const { enemies: updatedEnemies, kills, totalDamage } = damageEnemiesFromExplosion(enemies, exp.tiles, heroPower, exp.heroId);
               enemies = updatedEnemies;
               enemiesKilled += kills;
               if (kills > 0) {
@@ -503,13 +503,39 @@ const Index = () => {
                 eventLog.push(`💥 ${kills} ennemi(s) éliminé(s)!`);
                 coinsEarned += kills * 10;
               }
+              if (totalDamage > 0 && exp.heroId) {
+                const heroIdx = heroes.findIndex(h => h.id === exp.heroId);
+                if (heroIdx >= 0) {
+                  heroes[heroIdx] = {
+                    ...heroes[heroIdx],
+                    progressionStats: {
+                      ...heroes[heroIdx].progressionStats,
+                      totalDamageDealt: heroes[heroIdx].progressionStats.totalDamageDealt + totalDamage,
+                    },
+                  };
+                }
+              }
 
               if (boss && boss.hp > 0) {
                 const prevHp = boss.hp;
-                boss = damageBossFromExplosion(boss, exp.tiles, heroPower + 1);
+                const bossResult = damageBossFromExplosion(boss, exp.tiles, heroPower + 1);
+                boss = bossResult.boss;
                 if (boss.hp < prevHp) {
                   SFX.bossHit();
+                  const bossDamage = bossResult.damageDealt;
                   eventLog.push(`💥 Boss touché! (${boss.hp}/${boss.maxHp} HP)`);
+                  if (bossDamage > 0 && exp.heroId) {
+                    const heroIdx = heroes.findIndex(h => h.id === exp.heroId);
+                    if (heroIdx >= 0) {
+                      heroes[heroIdx] = {
+                        ...heroes[heroIdx],
+                        progressionStats: {
+                          ...heroes[heroIdx].progressionStats,
+                          totalDamageDealt: heroes[heroIdx].progressionStats.totalDamageDealt + bossDamage,
+                        },
+                      };
+                    }
+                  }
                 }
                 if (boss.hp <= 0 && prevHp > 0) {
                   eventLog.push(`👑 BOSS VAINCU!`);
@@ -673,9 +699,17 @@ const Index = () => {
     const updatedHeroes = player.heroes.map(h => {
       const deployed = gameState.heroes.find(dh => dh.id === h.id);
       if (!deployed) return h;
-      return completed
+      const baseHero = completed
         ? { ...h, ...deployed, currentStamina: deployed.maxStamina }
         : { ...h, ...deployed };
+      return {
+        ...baseHero,
+        progressionStats: {
+          ...baseHero.progressionStats,
+          battlesPlayed: baseHero.progressionStats.battlesPlayed + 1,
+          victories: baseHero.progressionStats.victories + (completed ? 1 : 0),
+        },
+      };
     });
     
     const newMapsCompleted = player.mapsCompleted + (completed ? 1 : 0);
@@ -1054,9 +1088,17 @@ const Index = () => {
       const storyUpdatedHeroes = player.heroes.map(h => {
         const deployed = stateSnapshot.heroes.find(dh => dh.id === h.id);
         if (!deployed) return h;
-        return stateSnapshot.mapCompleted
+        const baseHero = stateSnapshot.mapCompleted
           ? { ...h, ...deployed, currentStamina: deployed.maxStamina }
           : { ...h, ...deployed };
+        return {
+          ...baseHero,
+          progressionStats: {
+            ...baseHero.progressionStats,
+            battlesPlayed: baseHero.progressionStats.battlesPlayed + 1,
+            victories: baseHero.progressionStats.victories + (stateSnapshot.mapCompleted ? 1 : 0),
+          },
+        };
       });
 
       if (newHero && rewardedRarity) {


### PR DESCRIPTION
## Résumé

Implémente la feature de carte d'identité pour les héros (#55) avec:

- **Tracking des stats de progression**: coffres ouverts, dommages infligés, combats joués, victoires
- **UI carte d'identité**: nouvel onglet "Carte d'identité" dans le modal d'amélioration du héros
- **Persistance**: les stats sont sauvegardées et persistent après reload/deploy

## Modifications

- `src/game/engine.ts`: Mise à jour de `progressionStats.chestsOpened` à l'ouverture des coffres
- `src/game/enemyAI.ts`: Retourne `totalDamage` pour le tracking des dommages
- `src/pages/Index.tsx`: Tracking des battlesPlayed, victories et damage lors des combats
- `src/components/HeroUpgradeModal.tsx`: Nouvel onglet "Carte d'identité" affichant les stats

## Tests

- [x] Build passent (`npm run build`)
- [ ] Tester l'ouverture d'un coffre -> increment chestsOpened
- [ ] Tester un combat en mode Histoire -> increment battlesPlayed
- [ ] Tester la complétion d'une carte -> increment victories
- [ ] Vérifier la persistance après rechargement
- [ ] Vérifier l'affichage mobile