### PR TITLE
feat(treasure-hunt): add Hero Shards rewards on map completion (#142)

### DIFF
--- a/src/game/shardRewardSystem.ts
+++ b/src/game/shardRewardSystem.ts
@@ -1,0 +1,141 @@
+import { Rarity, MAP_CONFIGS } from './types';
+
+export type FarmTier = 'low' | 'medium' | 'high';
+
+export interface ShardDropRates {
+  common: number;
+  rare: number;
+  epic: number;
+  legend: number;
+}
+
+export const SHARD_DROP_RATES: Record<FarmTier, ShardDropRates> = {
+  low: {
+    common: 0.70,
+    rare: 0.25,
+    epic: 0.05,
+    legend: 0.00,
+  },
+  medium: {
+    common: 0.45,
+    rare: 0.40,
+    epic: 0.13,
+    legend: 0.02,
+  },
+  high: {
+    common: 0.25,
+    rare: 0.45,
+    epic: 0.24,
+    legend: 0.06,
+  },
+};
+
+export const FARM_TIER_THRESHOLDS: Record<number, FarmTier> = {
+  0: 'low',
+  1: 'low',
+  2: 'medium',
+  3: 'medium',
+  4: 'high',
+  5: 'high',
+};
+
+export function getFarmTier(mapIndex: number): FarmTier {
+  return FARM_TIER_THRESHOLDS[mapIndex] ?? 'low';
+}
+
+export function getDropRatesForMap(mapIndex: number): ShardDropRates {
+  const tier = getFarmTier(mapIndex);
+  return SHARD_DROP_RATES[tier];
+}
+
+export interface ShardReward {
+  rarity: Rarity;
+  quantity: number;
+}
+
+export function rollRarityFromRates(dropRates: ShardDropRates): Rarity {
+  const roll = Math.random();
+  let cumulative = 0;
+  
+  cumulative += dropRates.common;
+  if (roll < cumulative) return 'common';
+  
+  cumulative += dropRates.rare;
+  if (roll < cumulative) return 'rare';
+  
+  cumulative += dropRates.epic;
+  if (roll < cumulative) return 'epic';
+  
+  return 'legend';
+}
+
+export function generateShardRewards(mapIndex: number, rng?: () => number): ShardReward[] {
+  const dropRates = getDropRatesForMap(mapIndex);
+  const random = rng ?? Math.random;
+  
+  const shardCount = Math.floor(random() * 3) + 1;
+  const rewards: ShardReward[] = [];
+  
+  for (let i = 0; i < shardCount; i++) {
+    const roll = random();
+    let cumulative = 0;
+    let rarity: Rarity = 'common';
+    
+    cumulative += dropRates.common;
+    if (roll < cumulative) {
+      rarity = 'common';
+    } else {
+      cumulative += dropRates.rare;
+      if (roll < cumulative) {
+        rarity = 'rare';
+      } else {
+        cumulative += dropRates.epic;
+        if (roll < cumulative) {
+          rarity = 'epic';
+        } else {
+          rarity = 'legend';
+        }
+      }
+    }
+    
+    const existing = rewards.find(r => r.rarity === rarity);
+    if (existing) {
+      existing.quantity += 1;
+    } else {
+      rewards.push({ rarity, quantity: 1 });
+    }
+  }
+  
+  return rewards;
+}
+
+export function applyShardRewards(
+  currentShards: Record<Rarity, number>,
+  rewards: ShardReward[]
+): Record<Rarity, number> {
+  const newShards = { ...currentShards };
+  
+  for (const reward of rewards) {
+    newShards[reward.rarity] = (newShards[reward.rarity] || 0) + reward.quantity;
+  }
+  
+  return newShards;
+}
+
+export function getMapTierName(tier: FarmTier): string {
+  switch (tier) {
+    case 'low': return 'Débutant';
+    case 'medium': return 'Intermédiaire';
+    case 'high': return 'Avancé';
+  }
+}
+
+export function getMapInfoForTier(mapIndex: number): { tier: FarmTier; tierName: string; mapName: string } {
+  const tier = getFarmTier(mapIndex);
+  const mapConfig = MAP_CONFIGS[mapIndex];
+  return {
+    tier,
+    tierName: getMapTierName(tier),
+    mapName: mapConfig?.name ?? 'Inconnu',
+  };
+}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,7 @@ import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BOSS_RARITY_REWARD, Boss
 import { spawnEnemy, spawnBoss, tickEnemies, tickBoss, damageEnemiesFromExplosion, damageBossFromExplosion, checkEnemyHeroCollision, checkBossHeroCollision } from '@/game/enemyAI';
 import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
+import { generateShardRewards, applyShardRewards, ShardReward, getMapInfoForTier } from '@/game/shardRewardSystem';
 import DailyQuests from '@/components/DailyQuests';
 import Achievements from '@/components/Achievements';
 import PixelIcon from '@/components/PixelIcon';
@@ -89,6 +90,7 @@ const Index = () => {
   const [autoFarm, setAutoFarm] = useState(false);
   const [isMerging, setIsMerging] = useState(false);
   const [farmStats, setFarmStats] = useState({ runs: 0, totalCoins: 0 });
+  const [lastShardRewards, setLastShardRewards] = useState<ShardReward[]>([]);
   const [storyRegionIdx, setStoryRegionIdx] = useState(0);
   
   // Fusion UI state
@@ -726,6 +728,14 @@ const Index = () => {
     const { newState: chestState, unlocked: chestUnlocks } = trackChestsOpened(player.achievements, totalChestsOpened);
     Object.assign(newAchievements, chestState);
     newAchievementUnlocks.push(...chestUnlocks);
+
+    let newShards = player.shards;
+    let currentShardRewards: ShardReward[] = [];
+    if (completed && !gameState.isStoryMode) {
+      currentShardRewards = generateShardRewards(selectedMap);
+      newShards = applyShardRewards(player.shards, currentShardRewards);
+      setLastShardRewards(currentShardRewards);
+    }
     
     setPlayer(prev => ({
       ...prev,
@@ -734,6 +744,7 @@ const Index = () => {
       xp: prev.xp + earned,
       heroes: updatedHeroes,
       achievements: newAchievements,
+      shards: newShards,
     }));
     
     for (const achievement of newAchievementUnlocks) {
@@ -1937,6 +1948,23 @@ const Index = () => {
                 <p className="font-pixel text-lg sm:text-xl text-game-gold mt-2 flex items-center justify-center gap-2">
                   <Coins size={20} /> +{gameState.coinsEarned + (currentStoryStage?.reward || 0)} BC
                 </p>
+                {!gameState.isStoryMode && lastShardRewards.length > 0 && (
+                  <div className="mt-3 flex flex-wrap gap-2 justify-center">
+                    {lastShardRewards.map((reward, idx) => (
+                      <div
+                        key={idx}
+                        className={`font-pixel text-xs px-2 py-1 rounded flex items-center gap-1 ${
+                          reward.rarity === 'common' ? 'bg-gray-600 text-gray-200' :
+                          reward.rarity === 'rare' ? 'bg-blue-600 text-blue-200' :
+                          reward.rarity === 'epic' ? 'bg-purple-600 text-purple-200' :
+                          'bg-orange-600 text-orange-200'
+                        }`}
+                      >
+                        <Sparkles size={12} /> +{reward.quantity} {RARITY_CONFIG[reward.rarity].label}
+                      </div>
+                    ))}
+                  </div>
+                )}
                 {gameState.isStoryMode && (
                   <p className="text-xs text-muted-foreground mt-1">
                     +{currentStoryStage?.xpReward || 0} XP • {gameState.enemiesKilled || 0} ennemis éliminés

--- a/src/test/shardRewardSystem.test.ts
+++ b/src/test/shardRewardSystem.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect } from "vitest";
+import {
+  getFarmTier,
+  getDropRatesForMap,
+  generateShardRewards,
+  applyShardRewards,
+  SHARD_DROP_RATES,
+  FARM_TIER_THRESHOLDS,
+} from '@/game/shardRewardSystem';
+import { Rarity } from '@/game/types';
+
+describe('shardRewardSystem', () => {
+  describe('getFarmTier', () => {
+    it('should return low tier for early maps (Prairie, Forêt)', () => {
+      expect(getFarmTier(0)).toBe('low');
+      expect(getFarmTier(1)).toBe('low');
+    });
+
+    it('should return medium tier for middle maps (Mines, Château)', () => {
+      expect(getFarmTier(2)).toBe('medium');
+      expect(getFarmTier(3)).toBe('medium');
+    });
+
+    it('should return high tier for late maps (Volcan, Citadelle)', () => {
+      expect(getFarmTier(4)).toBe('high');
+      expect(getFarmTier(5)).toBe('high');
+    });
+
+    it('should return low tier for unknown map indices', () => {
+      expect(getFarmTier(99)).toBe('low');
+      expect(getFarmTier(-1)).toBe('low');
+    });
+  });
+
+  describe('getDropRatesForMap', () => {
+    it('should return correct drop rates for low tier', () => {
+      const rates = getDropRatesForMap(0);
+      expect(rates.common).toBe(0.70);
+      expect(rates.rare).toBe(0.25);
+      expect(rates.epic).toBe(0.05);
+      expect(rates.legend).toBe(0.00);
+    });
+
+    it('should return correct drop rates for medium tier', () => {
+      const rates = getDropRatesForMap(2);
+      expect(rates.common).toBe(0.45);
+      expect(rates.rare).toBe(0.40);
+      expect(rates.epic).toBe(0.13);
+      expect(rates.legend).toBe(0.02);
+    });
+
+    it('should return correct drop rates for high tier', () => {
+      const rates = getDropRatesForMap(4);
+      expect(rates.common).toBe(0.25);
+      expect(rates.rare).toBe(0.45);
+      expect(rates.epic).toBe(0.24);
+      expect(rates.legend).toBe(0.06);
+    });
+  });
+
+  describe('generateShardRewards', () => {
+    it('should generate between 1 and 3 shards', () => {
+      const deterministicRng = () => 0.5;
+      const rewards = generateShardRewards(0, deterministicRng);
+      const totalQuantity = rewards.reduce((sum, r) => sum + r.quantity, 0);
+      expect(totalQuantity).toBeGreaterThanOrEqual(1);
+      expect(totalQuantity).toBeLessThanOrEqual(3);
+    });
+
+    it('should generate deterministic results with seeded RNG', () => {
+      const deterministicRng = () => 0.5;
+      const rewards1 = generateShardRewards(0, deterministicRng);
+      const rewards2 = generateShardRewards(0, deterministicRng);
+      expect(rewards1).toEqual(rewards2);
+    });
+
+    it('should always return at least 1 shard', () => {
+      const veryLowRng = () => 0.001;
+      const rewards = generateShardRewards(0, veryLowRng);
+      expect(rewards.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('should handle multiple shards of same rarity', () => {
+      const rngCalls = [0.5, 0.1, 0.2];
+      let callIndex = 0;
+      const rng = () => rngCalls[callIndex++ % 3];
+      const rewards = generateShardRewards(0, rng);
+      expect(rewards.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe('applyShardRewards', () => {
+    it('should add shards to existing inventory', () => {
+      const currentShards: Record<Rarity, number> = {
+        common: 5,
+        rare: 3,
+        'super-rare': 0,
+        epic: 1,
+        legend: 0,
+        'super-legend': 0,
+      };
+      const rewards = [
+        { rarity: 'common' as Rarity, quantity: 2 },
+        { rarity: 'rare' as Rarity, quantity: 1 },
+      ];
+      const result = applyShardRewards(currentShards, rewards);
+      expect(result.common).toBe(7);
+      expect(result.rare).toBe(4);
+      expect(result.epic).toBe(1);
+    });
+
+    it('should initialize missing rarities to 0', () => {
+      const currentShards: Record<Rarity, number> = {
+        common: 5,
+        rare: 3,
+        'super-rare': 0,
+        epic: 1,
+        legend: 0,
+        'super-legend': 0,
+      };
+      const rewards = [
+        { rarity: 'legend' as Rarity, quantity: 10 },
+      ];
+      const result = applyShardRewards(currentShards, rewards);
+      expect(result.legend).toBe(10);
+    });
+
+    it('should not mutate original shards object', () => {
+      const currentShards: Record<Rarity, number> = {
+        common: 5,
+        rare: 3,
+        'super-rare': 0,
+        epic: 1,
+        legend: 0,
+        'super-legend': 0,
+      };
+      const originalCommon = currentShards.common;
+      const rewards = [{ rarity: 'common' as Rarity, quantity: 2 }];
+      applyShardRewards(currentShards, rewards);
+      expect(currentShards.common).toBe(originalCommon);
+    });
+  });
+
+  describe('SHARD_DROP_RATES', () => {
+    it('should have rates that sum to 1 for each tier', () => {
+      expect(SHARD_DROP_RATES.low.common + SHARD_DROP_RATES.low.rare + SHARD_DROP_RATES.low.epic + SHARD_DROP_RATES.low.legend).toBe(1);
+      expect(SHARD_DROP_RATES.medium.common + SHARD_DROP_RATES.medium.rare + SHARD_DROP_RATES.medium.epic + SHARD_DROP_RATES.medium.legend).toBe(1);
+      expect(SHARD_DROP_RATES.high.common + SHARD_DROP_RATES.high.rare + SHARD_DROP_RATES.high.epic + SHARD_DROP_RATES.high.legend).toBe(1);
+    });
+
+    it('should have probabilities that make sense for each tier', () => {
+      expect(SHARD_DROP_RATES.low.legend).toBeLessThan(SHARD_DROP_RATES.medium.legend);
+      expect(SHARD_DROP_RATES.medium.legend).toBeLessThan(SHARD_DROP_RATES.high.legend);
+      expect(SHARD_DROP_RATES.low.common).toBeGreaterThan(SHARD_DROP_RATES.high.common);
+    });
+  });
+
+  describe('FARM_TIER_THRESHOLDS', () => {
+    it('should map all MAP_CONFIGS indices', () => {
+      for (let i = 0; i < 6; i++) {
+        expect(FARM_TIER_THRESHOLDS[i]).toBeDefined();
+      }
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Ajoute un système de récompenses Hero Shards à la complétion des cartes de Chasse au Trésor
- Génère 1 à 3 shards par carte complétée avec une rareté pondérée selon le tier de farm

## Détails de l'implémentation

### Fichiers créés
- `src/game/shardRewardSystem.ts` - Système de génération de récompenses shards avec:
  - Configuration data-driven des taux de drop par tier (low/medium/high)
  - Tier bas (Prairie/Forêt): common 70%, rare 25%, epic 5%
  - Tier moyen (Mines/Château): common 45%, rare 40%, epic 13%, legendary 2%
  - Tier haut (Volcan/Citadelle): common 25%, rare 45%, epic 24%, legendary 6%
- `src/test/shardRewardSystem.test.ts` - 17 tests unitaires

### Fichiers modifiés
- `src/pages/Index.tsx` - Intégration dans le gameplay et UI de fin de run

## Vérifications effectuées
- ✅ `npm run test` - 27 tests passent
- ✅ `npm run build` - Build réussi
- Les taux sont configurables dans `SHARD_DROP_RATES` (data-driven)