### PR TITLE
Add shard reward system for farming maps

### DIFF
--- a/src/game/shardRewardSystem.ts
+++ b/src/game/shardRewardSystem.ts
@@ -1,4 +1,4 @@
-import { Rarity, MAP_CONFIGS } from './types';
+import { Rarity } from './types';
 
 export type FarmTier = 'low' | 'medium' | 'high';
 
@@ -53,51 +53,31 @@ export interface ShardReward {
   quantity: number;
 }
 
-export function rollRarityFromRates(dropRates: ShardDropRates): Rarity {
-  const roll = Math.random();
+export function rollRarityFromRates(dropRates: ShardDropRates, roll: number): Rarity {
   let cumulative = 0;
-  
+
   cumulative += dropRates.common;
   if (roll < cumulative) return 'common';
-  
+
   cumulative += dropRates.rare;
   if (roll < cumulative) return 'rare';
-  
+
   cumulative += dropRates.epic;
   if (roll < cumulative) return 'epic';
-  
+
   return 'legend';
 }
 
 export function generateShardRewards(mapIndex: number, rng?: () => number): ShardReward[] {
   const dropRates = getDropRatesForMap(mapIndex);
   const random = rng ?? Math.random;
-  
+
   const shardCount = Math.floor(random() * 3) + 1;
   const rewards: ShardReward[] = [];
-  
+
   for (let i = 0; i < shardCount; i++) {
-    const roll = random();
-    let cumulative = 0;
-    let rarity: Rarity = 'common';
-    
-    cumulative += dropRates.common;
-    if (roll < cumulative) {
-      rarity = 'common';
-    } else {
-      cumulative += dropRates.rare;
-      if (roll < cumulative) {
-        rarity = 'rare';
-      } else {
-        cumulative += dropRates.epic;
-        if (roll < cumulative) {
-          rarity = 'epic';
-        } else {
-          rarity = 'legend';
-        }
-      }
-    }
-    
+    const rarity = rollRarityFromRates(dropRates, random());
+
     const existing = rewards.find(r => r.rarity === rarity);
     if (existing) {
       existing.quantity += 1;
@@ -105,7 +85,7 @@ export function generateShardRewards(mapIndex: number, rng?: () => number): Shar
       rewards.push({ rarity, quantity: 1 });
     }
   }
-  
+
   return rewards;
 }
 
@@ -122,20 +102,3 @@ export function applyShardRewards(
   return newShards;
 }
 
-export function getMapTierName(tier: FarmTier): string {
-  switch (tier) {
-    case 'low': return 'Débutant';
-    case 'medium': return 'Intermédiaire';
-    case 'high': return 'Avancé';
-  }
-}
-
-export function getMapInfoForTier(mapIndex: number): { tier: FarmTier; tierName: string; mapName: string } {
-  const tier = getFarmTier(mapIndex);
-  const mapConfig = MAP_CONFIGS[mapIndex];
-  return {
-    tier,
-    tierName: getMapTierName(tier),
-    mapName: mapConfig?.name ?? 'Inconnu',
-  };
-}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,7 +21,7 @@ import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BOSS_RARITY_REWARD, Boss
 import { spawnEnemy, spawnBoss, tickEnemies, tickBoss, damageEnemiesFromExplosion, damageBossFromExplosion, checkEnemyHeroCollision, checkBossHeroCollision } from '@/game/enemyAI';
 import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
-import { generateShardRewards, applyShardRewards, ShardReward, getMapInfoForTier } from '@/game/shardRewardSystem';
+import { generateShardRewards, applyShardRewards, ShardReward } from '@/game/shardRewardSystem';
 import DailyQuests from '@/components/DailyQuests';
 import Achievements from '@/components/Achievements';
 import PixelIcon from '@/components/PixelIcon';
@@ -674,6 +674,7 @@ const Index = () => {
       deployedHeroes.push(firstHero);
     }
 
+    setLastShardRewards([]);
     setGameState({
       map,
       heroes: deployedHeroes,

--- a/src/test/shardRewardSystem.test.ts
+++ b/src/test/shardRewardSystem.test.ts
@@ -4,6 +4,7 @@ import {
   getDropRatesForMap,
   generateShardRewards,
   applyShardRewards,
+  rollRarityFromRates,
   SHARD_DROP_RATES,
   FARM_TIER_THRESHOLDS,
 } from '@/game/shardRewardSystem';
@@ -143,9 +144,9 @@ describe('shardRewardSystem', () => {
 
   describe('SHARD_DROP_RATES', () => {
     it('should have rates that sum to 1 for each tier', () => {
-      expect(SHARD_DROP_RATES.low.common + SHARD_DROP_RATES.low.rare + SHARD_DROP_RATES.low.epic + SHARD_DROP_RATES.low.legend).toBe(1);
-      expect(SHARD_DROP_RATES.medium.common + SHARD_DROP_RATES.medium.rare + SHARD_DROP_RATES.medium.epic + SHARD_DROP_RATES.medium.legend).toBe(1);
-      expect(SHARD_DROP_RATES.high.common + SHARD_DROP_RATES.high.rare + SHARD_DROP_RATES.high.epic + SHARD_DROP_RATES.high.legend).toBe(1);
+      expect(SHARD_DROP_RATES.low.common + SHARD_DROP_RATES.low.rare + SHARD_DROP_RATES.low.epic + SHARD_DROP_RATES.low.legend).toBeCloseTo(1);
+      expect(SHARD_DROP_RATES.medium.common + SHARD_DROP_RATES.medium.rare + SHARD_DROP_RATES.medium.epic + SHARD_DROP_RATES.medium.legend).toBeCloseTo(1);
+      expect(SHARD_DROP_RATES.high.common + SHARD_DROP_RATES.high.rare + SHARD_DROP_RATES.high.epic + SHARD_DROP_RATES.high.legend).toBeCloseTo(1);
     });
 
     it('should have probabilities that make sense for each tier', () => {
@@ -160,6 +161,26 @@ describe('shardRewardSystem', () => {
       for (let i = 0; i < 6; i++) {
         expect(FARM_TIER_THRESHOLDS[i]).toBeDefined();
       }
+    });
+  });
+
+  describe('rollRarityFromRates', () => {
+    it('should return common for low rolls', () => {
+      expect(rollRarityFromRates(SHARD_DROP_RATES.low, 0.0)).toBe('common');
+      expect(rollRarityFromRates(SHARD_DROP_RATES.low, 0.69)).toBe('common');
+    });
+
+    it('should return rare for mid rolls', () => {
+      expect(rollRarityFromRates(SHARD_DROP_RATES.low, 0.71)).toBe('rare');
+      expect(rollRarityFromRates(SHARD_DROP_RATES.low, 0.94)).toBe('rare');
+    });
+
+    it('should return epic for high rolls', () => {
+      expect(rollRarityFromRates(SHARD_DROP_RATES.low, 0.96)).toBe('epic');
+    });
+
+    it('should return legend for highest rolls on high tier', () => {
+      expect(rollRarityFromRates(SHARD_DROP_RATES.high, 0.99)).toBe('legend');
     });
   });
 });


### PR DESCRIPTION
## Résumé
Ajoute un système de récompense de shards pour les runs de farming sur les cartes non-story. Les shards sont générés selon le tier de la carte (low/medium/high) avec des probabilités de rareté différentes, et s'affichent dans l'écran de victoire.

## Issue liée (obligatoire)
Fixes #[numéro de l'issue]

## Type de changement
- [x] Feature
- [ ] Fix
- [ ] UI/UX
- [ ] Balance
- [ ] Refactor
- [ ] Docs

## Détails des changements

### Nouveau fichier: `src/game/shardRewardSystem.ts`
- Implémente la logique complète du système de récompense de shards
- Définit les tiers de farming (low/medium/high) basés sur l'index de la carte
- Configure les taux de drop pour chaque rareté selon le tier
- Fournit des fonctions pour :
  - Déterminer le tier d'une carte (`getFarmTier`)
  - Obtenir les taux de drop (`getDropRatesForMap`)
  - Générer des récompenses aléatoires (`generateShardRewards`)
  - Appliquer les récompenses à l'inventaire (`applyShardRewards`)
  - Déterminer la rareté selon les probabilités (`rollRarityFromRates`)

### Tests: `src/test/shardRewardSystem.test.ts`
- Suite complète de tests unitaires couvrant tous les cas d'usage
- Tests des tiers de cartes, taux de drop, génération de récompenses
- Validation que les probabilités sont correctes et cohérentes
- Tests de déterminisme avec RNG personnalisé

### Intégration: `src/pages/Index.tsx`
- Génère les shards après chaque run de farming (non-story)
- Applique les récompenses à l'inventaire du joueur
- Affiche les shards gagnés dans l'écran de victoire avec code couleur par rareté
- Réinitialise l'affichage des récompenses au démarrage d'une nouvelle carte

## Vérifications
- [x] J'ai testé localement
- [x] Le build passe
- [x] J'ai ajouté les tests unitaires
- [ ] La PR est liée à une issue

## Notes complémentaires
- Les shards ne sont générés que pour les runs de farming (pas en story mode)
- Les probabilités augmentent pour les raretés supérieures sur les cartes plus difficiles
- L'affichage des récompenses utilise les couleurs existantes du système de rareté
- Le système supporte les RNG personnalisés pour les tests déterministes

https://claude.ai/code/session_01ARBNXSwGmWLMgJqWGjKzLo