### PR TITLE
fix(gameplay): move MERGE_RECIPES to module level to prevent TDZ crash

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -62,6 +62,16 @@ const DEFAULT_HERO_FILTERS: HeroFilters = {
   level: 'all',
 };
 
+// Merge system - ratios from issue #93
+// Declared at module level to avoid TDZ when used in useEffect before const declaration inside component
+const MERGE_RECIPES: { from: Rarity; to: Rarity; count: number }[] = [
+  { from: 'common', to: 'rare', count: 2 },
+  { from: 'rare', to: 'super-rare', count: 3 },
+  { from: 'super-rare', to: 'epic', count: 4 },
+  { from: 'epic', to: 'legend', count: 5 },
+  { from: 'legend', to: 'super-legend', count: 6 },
+];
+
 const Index = () => {
   const { user, session, loading: authLoading, signOut } = useAuth();
   const navigate = useNavigate();
@@ -790,14 +800,7 @@ const Index = () => {
     }
   }, [autoFarm, gameState?.mapCompleted, collectAndContinue]);
 
-  // Merge system - ratios from issue #93
-  const MERGE_RECIPES: { from: Rarity; to: Rarity; count: number }[] = [
-    { from: 'common', to: 'rare', count: 2 },
-    { from: 'rare', to: 'super-rare', count: 3 },
-    { from: 'super-rare', to: 'epic', count: 4 },
-    { from: 'epic', to: 'legend', count: 5 },
-    { from: 'legend', to: 'super-legend', count: 6 },
-  ];
+  // MERGE_RECIPES is now declared at module level (above) to prevent TDZ crash
 
   const isHeroEligibleForMerge = (hero: Hero, rarity: Rarity, requiredCount: number): { eligible: boolean; reason: string } => {
     const maxLevel = RARITY_CONFIG[rarity].maxLevel;


### PR DESCRIPTION
## Summary

- Moves `MERGE_RECIPES` constant from inside the `Index` component body to module level
- Fixes `ReferenceError: Cannot access 'et' before initialization` crash in production
- The TDZ (Temporal Dead Zone) was triggered by Vite/Rollup reordering code during bundling, causing the `const` to be used before its declaration

Closes #178

## Root cause

`MERGE_RECIPES` was declared at line ~794 inside the component, but referenced at line ~119 in a `useEffect`. In development this worked due to hoisting behavior, but Rollup's dead code elimination and tree-shaking reordered execution, exposing the TDZ.

## Fix

Moving the constant to module scope ensures it is always initialized before any component code runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)