### PR TITLE
fix: changelog — plus de vUnreleased, dates et versions correctes

### DIFF
--- a/scripts/update-changelog-from-pr.mjs
+++ b/scripts/update-changelog-from-pr.mjs
@@ -46,11 +46,20 @@ function insertIntoUnreleased(src) {
   const unreleasedIndex = src.indexOf("version: 'Unreleased'");
   if (unreleasedIndex === -1) return null;
 
-  const changesIndex = src.indexOf('changes: [', unreleasedIndex);
+  // Met à jour la date du bloc Unreleased à la date du jour
+  const today = new Date().toISOString().slice(0, 10);
+  const datePattern = /date: '[^']*'(?=[\s\S]*?title: 'Mises à jour récentes')/;
+  let updated = src;
+  const blockEnd = src.indexOf('  },', unreleasedIndex);
+  const block = src.slice(unreleasedIndex, blockEnd);
+  const updatedBlock = block.replace(/date: '[^']*'/, `date: '${today}'`);
+  updated = src.slice(0, unreleasedIndex) + updatedBlock + src.slice(blockEnd);
+
+  const changesIndex = updated.indexOf('changes: [', unreleasedIndex);
   if (changesIndex === -1) return null;
 
   const insertPos = changesIndex + 'changes: [\n'.length;
-  return src.slice(0, insertPos) + changeLine + src.slice(insertPos);
+  return updated.slice(0, insertPos) + changeLine + updated.slice(insertPos);
 }
 
 function insertNewUnreleased(src) {

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -10,8 +10,8 @@ export interface ChangelogEntry {
 
 export const CHANGELOG: ChangelogEntry[] = [
   {
-    version: 'Unreleased',
-    date: '2026-03-15',
+    version: '1.7.0',
+    date: '2026-03-18',
     title: 'Mises à jour récentes',
     changes: [
       { type: 'feature', description: 'ci: GitHub Actions workflow + TypeScript strict (Issue #3) (#182)' },

--- a/src/pages/Changelog.tsx
+++ b/src/pages/Changelog.tsx
@@ -93,8 +93,12 @@ const Changelog: React.FC = () => {
                   <div className="pixel-border bg-card p-5">
                     {/* Version header */}
                     <div className="flex flex-wrap items-center gap-3 mb-3">
-                      <span className="font-pixel text-[10px] text-primary text-glow-red">v{entry.version}</span>
-                      <span className="text-[10px] text-muted-foreground">{formatDate(entry.date)}</span>
+                      <span className="font-pixel text-[10px] text-primary text-glow-red">
+                        {entry.version === 'Unreleased' ? 'En cours' : `v${entry.version}`}
+                      </span>
+                      {entry.date && entry.date !== 'Unreleased' && (
+                        <span className="text-[10px] text-muted-foreground">{formatDate(entry.date)}</span>
+                      )}
                     </div>
                     <h2 className="font-pixel text-[9px] text-foreground mb-4">{entry.title}</h2>
 


### PR DESCRIPTION
## Problème

La page Changelog affichait **`vUnreleased`** parce que :
- `src/data/changelog.ts` avait `version: 'Unreleased'` sur le premier bloc
- `src/pages/Changelog.tsx` faisait `v{entry.version}` sans guard
- `scripts/update-changelog-from-pr.mjs` insérait toutes les PRs dans un bloc Unreleased sans jamais mettre à jour la date

## Corrections

| Fichier | Fix |
|---|---|
| `src/data/changelog.ts` | `'Unreleased'` → `'1.7.0'`, date mise à jour |
| `src/pages/Changelog.tsx` | Affiche `En cours` si `version === 'Unreleased'`, gestion propre des dates manquantes |
| `scripts/update-changelog-from-pr.mjs` | Rafraîchit la date du bloc Unreleased à chaque insertion de PR |

## Test plan
- [ ] La page Changelog n'affiche plus `vUnreleased`
- [ ] Les dates s'affichent correctement
- [ ] Le script `update-changelog-from-pr.mjs` met bien à jour la date

🤖 Generated with [Claude Code](https://claude.com/claude-code)