### PR TITLE
fix: suppression de compte via RPC au lieu de auth.admin (#161)

### DIFF
--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -74,34 +74,28 @@ export default function Profile() {
     setDeleting(true);
     
     try {
-      const userId = user.id;
-      
-      await supabase.from('player_saves').delete().eq('user_id', userId);
-      await supabase.from('player_heroes').delete().eq('user_id', userId);
-      await supabase.from('profiles').delete().eq('user_id', userId);
-      
-      const { error: deleteAuthError } = await supabase.auth.admin.deleteUser(userId);
-      
-      if (deleteAuthError) {
-        console.error('Error deleting auth user:', deleteAuthError);
-        toast({ 
-          title: 'Erreur', 
-          description: 'Impossible de supprimer le compte. Veuillez réessayer.', 
-          variant: 'destructive' 
+      const { error: deleteError } = await supabase.rpc('delete_user_account');
+
+      if (deleteError) {
+        console.error('Error deleting account:', deleteError);
+        toast({
+          variant: 'destructive',
+          title: 'Erreur',
+          description: 'Impossible de supprimer le compte. Veuillez réessayer.',
         });
         setDeleting(false);
         return;
       }
-      
+
       await signOut();
       toast({ title: 'Compte supprimé', description: 'Ton compte a été supprimé avec succès.' });
       navigate('/');
     } catch (err) {
       console.error('Error deleting account:', err);
-      toast({ 
-        title: 'Erreur', 
-        description: 'Une erreur est survenue lors de la suppression du compte.', 
-        variant: 'destructive' 
+      toast({
+        title: 'Erreur',
+        description: 'Une erreur est survenue lors de la suppression du compte.',
+        variant: 'destructive'
       });
       setDeleting(false);
     }

--- a/src/test/deleteAccount.test.ts
+++ b/src/test/deleteAccount.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('delete_user_account RPC', () => {
+  it('calls supabase.rpc delete_user_account, not auth.admin', () => {
+    // Vérifie que le bon pattern est utilisé dans Profile.tsx
+    // Ce test documente la régression à éviter
+    const profileCode = `supabase.rpc('delete_user_account')`;
+    const forbiddenCode = `supabase.auth.admin.deleteUser`;
+
+    const code = readFileSync(resolve(__dirname, '../pages/Profile.tsx'), 'utf8');
+
+    expect(code).toContain(profileCode);
+    expect(code).not.toContain(forbiddenCode);
+  });
+});

--- a/supabase/migrations/20260318120000_add_delete_user_account_rpc.sql
+++ b/supabase/migrations/20260318120000_add_delete_user_account_rpc.sql
@@ -1,0 +1,28 @@
+-- Permet à un utilisateur connecté de supprimer son propre compte
+-- SECURITY DEFINER = s'exécute avec les droits du propriétaire (postgres)
+CREATE OR REPLACE FUNCTION delete_user_account()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  _uid uuid := auth.uid();
+BEGIN
+  IF _uid IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+
+  -- Supprimer les données applicatives
+  DELETE FROM player_heroes WHERE user_id = _uid;
+  DELETE FROM player_saves WHERE user_id = _uid;
+  DELETE FROM profiles WHERE user_id = _uid;
+
+  -- Supprimer le compte auth (possible car SECURITY DEFINER avec accès auth schema)
+  DELETE FROM auth.users WHERE id = _uid;
+END;
+$$;
+
+-- Accorder l'exécution aux utilisateurs authentifiés uniquement
+REVOKE ALL ON FUNCTION delete_user_account() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION delete_user_account() TO authenticated;


### PR DESCRIPTION
Closes #161

## Root cause

`supabase.auth.admin.deleteUser()` est une API **serveur uniquement** qui requiert la service role key. Appelée depuis le frontend avec la clé anon, elle échoue systématiquement avec une erreur 403.

## Solution

### Migration SQL — `delete_user_account()` RPC

Nouvelle fonction `SECURITY DEFINER` dans `supabase/migrations/20260318120000_add_delete_user_account_rpc.sql` :
- Supprime `player_heroes` → `player_saves` → `profiles` → `auth.users` en une transaction atomique
- Accès restreint aux utilisateurs authentifiés (`GRANT EXECUTE TO authenticated`)

### Frontend — `Profile.tsx`

Remplace les 4 appels séparés par un unique `supabase.rpc('delete_user_account')`.
Flow post-suppression conservé : `signOut()` + `navigate('/')` + toast.

### Test de non-régression

`src/test/deleteAccount.test.ts` vérifie que le code n'utilise plus jamais `supabase.auth.admin.deleteUser`.

## Avantage

L'opération est désormais **atomique** — plus de risque de suppression partielle.

## ⚠️ Action requise après merge

Appliquer la migration Supabase :
```bash
supabase db push
```

## Test plan
- [ ] Suppression de compte fonctionne (plus d'erreur 403)
- [ ] Déconnexion + redirect `/` après suppression
- [ ] Données supprimées dans toutes les tables
- [ ] `npm run test` passe

🤖 Generated with [Claude Code](https://claude.com/claude-code)