### PR TITLE
feat: Universal Hero Shards (#150)

### DIFF
--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -8,7 +8,7 @@ export interface ChangelogEntry {
   }[];
 }
 
-export const CHANGELOG: ChangelogEntry[
+export const CHANGELOG: ChangelogEntry[] = [
   {
     version: 'Unreleased',
     date: '2026-03-18',
@@ -16,7 +16,7 @@ export const CHANGELOG: ChangelogEntry[
     changes: [
       { type: 'feature', description: 'fix: changelog — plus de vUnreleased, dates et versions correctes (#185)' },
     ],
-  },] = [
+  },
   {
     version: '1.7.0',
     date: '2026-03-18',

--- a/src/game/saveSystem.ts
+++ b/src/game/saveSystem.ts
@@ -26,6 +26,7 @@ export function getDefaultPlayerData(): PlayerData {
       legend: 0,
       'super-legend': 0,
     } as Record<Rarity, number>,
+    universalShards: 0,
     huntSpeed: 1,
     achievements: getDefaultAchievementState(),
   };
@@ -46,6 +47,12 @@ export function loadPlayerData(): PlayerData {
       const parsed = JSON.parse(saved);
       if (!parsed.achievements) {
         parsed.achievements = getDefaultAchievementState();
+      }
+      if (parsed.universalShards === undefined) {
+        // Migration: convertir les anciens shards par rareté en universalShards
+        const s = parsed.shards || { common: 0, rare: 0, 'super-rare': 0, epic: 0, legend: 0, 'super-legend': 0 };
+        parsed.universalShards = (s.common || 0) + (s.rare || 0) * 2 + (s['super-rare'] || 0) * 4 + (s.epic || 0) * 10 + (s.legend || 0) * 25 + (s['super-legend'] || 0) * 100;
+        parsed.shards = { common: 0, rare: 0, 'super-rare': 0, epic: 0, legend: 0, 'super-legend': 0 };
       }
       parsed.xp = Number.isFinite(Number(parsed?.xp)) ? Number(parsed.xp) : 0;
       if (Array.isArray(parsed.heroes)) {

--- a/src/game/shardRewardSystem.ts
+++ b/src/game/shardRewardSystem.ts
@@ -94,11 +94,21 @@ export function applyShardRewards(
   rewards: ShardReward[]
 ): Record<Rarity, number> {
   const newShards = { ...currentShards };
-  
+
   for (const reward of rewards) {
     newShards[reward.rarity] = (newShards[reward.rarity] || 0) + reward.quantity;
   }
-  
+
   return newShards;
+}
+
+export function generateUniversalShardReward(mapIndex: number): number {
+  // Montant en universalShards selon le tier de carte
+  const tier = getFarmTier(mapIndex);
+  const amounts: Record<FarmTier, number> = { low: 3, medium: 6, high: 12 };
+  const base = amounts[tier];
+  // +0 à +50% bonus aléatoire
+  const bonus = Math.floor(base * Math.random() * 0.5);
+  return base + bonus;
 }
 

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -141,7 +141,9 @@ export interface PlayerData {
   };
   totalHeroesOwned: number;
   mapsCompleted: number;
+  /** @deprecated Migré vers universalShards */
   shards: Record<Rarity, number>;
+  universalShards: number;
   huntSpeed?: number;
   achievements: AchievementState;
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,7 +21,7 @@ import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BOSS_RARITY_REWARD, Boss
 import { spawnEnemy, spawnBoss, tickEnemies, tickBoss, damageEnemiesFromExplosion, damageBossFromExplosion, checkEnemyHeroCollision, checkBossHeroCollision } from '@/game/enemyAI';
 import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
-import { generateShardRewards, applyShardRewards, ShardReward } from '@/game/shardRewardSystem';
+import { generateShardRewards, applyShardRewards, ShardReward, generateUniversalShardReward } from '@/game/shardRewardSystem';
 import DailyQuests from '@/components/DailyQuests';
 import Achievements from '@/components/Achievements';
 import XpBar from '@/components/XpBar';
@@ -741,14 +741,12 @@ const Index = () => {
     Object.assign(newAchievements, chestState);
     newAchievementUnlocks.push(...chestUnlocks);
 
-    let newShards = player.shards;
-    let currentShardRewards: ShardReward[] = [];
+    let universalShardsGained = 0;
     if (completed && !gameState.isStoryMode) {
-      currentShardRewards = generateShardRewards(selectedMap);
-      newShards = applyShardRewards(player.shards, currentShardRewards);
-      setLastShardRewards(currentShardRewards);
+      universalShardsGained = generateUniversalShardReward(selectedMap);
+      setLastShardRewards([{ rarity: 'common', quantity: universalShardsGained }]);
     }
-    
+
     setPlayer(prev => ({
       ...prev,
       bomberCoins: prev.bomberCoins + earned,
@@ -756,7 +754,7 @@ const Index = () => {
       xp: prev.xp + earned,
       heroes: updatedHeroes,
       achievements: newAchievements,
-      shards: newShards,
+      universalShards: prev.universalShards + universalShardsGained,
     }));
     
     for (const achievement of newAchievementUnlocks) {

--- a/src/pages/Summon.tsx
+++ b/src/pages/Summon.tsx
@@ -11,7 +11,7 @@ import { trackSummon, trackRarityUnlock, trackHeroCount } from '@/game/achieveme
 import { toast } from '@/hooks/use-toast';
 import { ArrowLeft, Sparkles, Star, Coins, Gem, ArrowRight } from 'lucide-react';
 
-const SHARD_COSTS: Record<Rarity, number> = {
+const UNIVERSAL_SHARD_COSTS: Record<Rarity, number> = {
   common: 10,
   rare: 50,
   'super-rare': 150,
@@ -217,11 +217,8 @@ const Summon: React.FC = () => {
     Object.assign(newAchievements, heroCountState);
     newAchievementUnlocks.push(...heroCountUnlocks);
 
-    const newShards = { ...player.shards };
     const rarities: Rarity[] = ['common', 'rare', 'super-rare', 'epic', 'legend', 'super-legend'];
-    for (const hero of batch) {
-      newShards[hero.rarity] = (newShards[hero.rarity] || 0) + (rarities.indexOf(hero.rarity) + 1);
-    }
+    const universalShardsBonus = batch.reduce((acc, hero) => acc + (rarities.indexOf(hero.rarity) + 1), 0);
 
     setPlayer(prev => ({
       ...prev,
@@ -230,7 +227,7 @@ const Summon: React.FC = () => {
       pityCounters: currentPity,
       totalHeroesOwned: mergedHeroes.length,
       achievements: newAchievements,
-      shards: newShards,
+      universalShards: prev.universalShards + universalShardsBonus,
     }));
 
     for (const achievement of newAchievementUnlocks) {
@@ -257,7 +254,7 @@ const Summon: React.FC = () => {
       pityCounters: currentPity,
       totalHeroesOwned: mergedHeroes.length,
       achievements: newAchievements,
-      shards: newShards,
+      universalShards: player.universalShards + universalShardsBonus,
     };
     savePlayerData(updatedData);
     if (canWriteCloud) {
@@ -267,13 +264,12 @@ const Summon: React.FC = () => {
   };
 
   const handleSummonShards = () => {
-    const cost = SHARD_COSTS[selectedShardRarity];
-    const currentShards = player.shards[selectedShardRarity] || 0;
-    
-    if (currentShards < cost) {
-      toast({ 
-        title: 'Fragments insuffisants', 
-        description: `Il te faut ${cost} fragments ${selectedShardRarity} pour cette invocation.` 
+    const cost = UNIVERSAL_SHARD_COSTS[selectedShardRarity];
+
+    if (player.universalShards < cost) {
+      toast({
+        title: 'Fragments insuffisants',
+        description: `Il te faut ${cost} Shards Universels pour cette invocation.`,
       });
       return;
     }
@@ -281,9 +277,6 @@ const Summon: React.FC = () => {
     setAnimating(true);
     setShowResult(false);
     setShowExplosion(false);
-
-    const newShards = { ...player.shards };
-    newShards[selectedShardRarity] = currentShards - cost;
 
     const newHero = generateHero(selectedShardRarity);
     const newHeroes = [...player.heroes, newHero];
@@ -294,7 +287,7 @@ const Summon: React.FC = () => {
     const newTotalSummons = player.totalHeroesOwned + 1;
     const newAchievements = { ...player.achievements };
     const newAchievementUnlocks: any[] = [];
-    
+
     const { newState: summonState, unlocked: summonUnlocks } = trackSummon(player.achievements, newTotalSummons);
     Object.assign(newAchievements, summonState);
     newAchievementUnlocks.push(...summonUnlocks);
@@ -308,7 +301,7 @@ const Summon: React.FC = () => {
       heroes: newHeroes,
       totalHeroesOwned: newHeroes.length,
       achievements: newAchievements,
-      shards: newShards,
+      universalShards: prev.universalShards - cost,
     }));
 
     for (const achievement of newAchievementUnlocks) {
@@ -331,7 +324,7 @@ const Summon: React.FC = () => {
       heroes: newHeroes,
       totalHeroesOwned: newHeroes.length,
       achievements: newAchievements,
-      shards: newShards,
+      universalShards: player.universalShards - cost,
     };
     savePlayerData(updatedData);
     if (canWriteCloud) {
@@ -397,13 +390,17 @@ const Summon: React.FC = () => {
               <div className="flex items-center gap-2">
                 <Gem size={16} className="text-secondary" />
                 <span className="font-pixel text-[8px] text-muted-foreground">
-                  {player.shards[selectedShardRarity] || 0} / {SHARD_COSTS[selectedShardRarity]} {selectedShardRarity}
+                  💎 {player.universalShards} Shards Universels
                 </span>
               </div>
             </div>
 
             {activeTab === 'shards' && (
               <div className="mb-4">
+                <div className="flex items-center justify-center gap-2 mb-3 p-2 rounded bg-secondary/10 border border-secondary/30">
+                  <Gem size={14} className="text-secondary" />
+                  <span className="font-pixel text-[8px] text-secondary">💎 {player.universalShards} Shards Universels</span>
+                </div>
                 <p className="font-pixel text-[7px] text-muted-foreground mb-2">Sélectionne la rareté:</p>
                 <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
                   {(['rare', 'super-rare', 'epic', 'legend', 'super-legend'] as Rarity[]).map((r) => (
@@ -425,7 +422,7 @@ const Summon: React.FC = () => {
                           {RARITY_CONFIG[r].label}
                         </span>
                         <span className="font-pixel text-[5px] text-muted-foreground block mt-0.5">
-                          {SHARD_COSTS[r]}
+                          {UNIVERSAL_SHARD_COSTS[r]}
                         </span>
                       </div>
                     </button>
@@ -595,7 +592,7 @@ const Summon: React.FC = () => {
 
                     <button
                       onClick={handleSummonShards}
-                      disabled={animating || (player.shards[selectedShardRarity] || 0) < SHARD_COSTS[selectedShardRarity]}
+                      disabled={animating || player.universalShards < UNIVERSAL_SHARD_COSTS[selectedShardRarity]}
                       className="pixel-btn w-full text-center disabled:opacity-40"
                       style={{ background: `linear-gradient(135deg, hsl(var(--game-rarity-${selectedShardRarity})), hsl(var(--game-rarity-${selectedShardRarity}) / 0.7))` }}
                     >
@@ -605,7 +602,7 @@ const Summon: React.FC = () => {
                         <ArrowRight size={14} />
                       </div>
                       <div className="font-pixel text-[8px] text-white/80 mt-0.5">
-                        Coût: {SHARD_COSTS[selectedShardRarity]} fragments {selectedShardRarity}
+                        Coût: {UNIVERSAL_SHARD_COSTS[selectedShardRarity]} Shards Universels
                       </div>
                     </button>
                   </div>


### PR DESCRIPTION
## Summary
- Ajoute `universalShards` comme monnaie unique de shards dans PlayerData
- Migration automatique des anciens shards par rareté (conversion pondérée)
- Les récompenses de Chasse au Trésor créditent universalShards directement
- Summon.tsx utilise universalShards pour les invocations ciblées

## Closes
Fixes #150

## Test plan
- [ ] Build passe
- [ ] Tests passent
- [ ] Nouvelle partie : universalShards = 0 au départ
- [ ] Ancienne save : migration applique la conversion
- [ ] Chasse au Trésor complétée : universalShards augmente
- [ ] Invocation ciblée : universalShards débités