### PR TITLE
feat: recyclage de héros en Universal Shards (#148)

### DIFF
--- a/src/components/RecyclePanel.tsx
+++ b/src/components/RecyclePanel.tsx
@@ -1,0 +1,136 @@
+import { useState } from 'react';
+import { Hero } from '@/game/types';
+import { getRecycleValue } from '@/game/recycleSystem';
+import { Button } from '@/components/ui/button';
+import { Trash2, Lock, Unlock, RefreshCw } from 'lucide-react';
+
+interface RecyclePanelProps {
+  heroes: Hero[];
+  universalShards: number;
+  onRecycle: (ids: string[], shardsGained: number) => void;
+  onToggleLock: (heroId: string) => void;
+}
+
+export default function RecyclePanel({ heroes, universalShards, onRecycle, onToggleLock }: RecyclePanelProps) {
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [showConfirm, setShowConfirm] = useState(false);
+
+  const toggleSelect = (id: string) => {
+    const hero = heroes.find(h => h.id === id);
+    if (hero?.isLocked) return; // Pas de sélection des héros lockés
+    setSelectedIds(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const selectedHeroes = heroes.filter(h => selectedIds.has(h.id));
+  const totalShards = selectedHeroes.reduce((acc, h) => acc + getRecycleValue(h), 0);
+
+  const handleConfirmRecycle = () => {
+    onRecycle([...selectedIds], totalShards);
+    setSelectedIds(new Set());
+    setShowConfirm(false);
+  };
+
+  // Sélectionner tous les doublons non-lockés
+  const selectAllDuplicates = () => {
+    const seen = new Map<string, number>();
+    heroes.forEach(h => seen.set(h.name.split(' #')[0], (seen.get(h.name.split(' #')[0]) || 0) + 1));
+    const duplicateIds = heroes
+      .filter(h => !h.isLocked && (seen.get(h.name.split(' #')[0]) || 0) > 1)
+      .map(h => h.id);
+    setSelectedIds(new Set(duplicateIds));
+  };
+
+  const rarityColors: Record<string, string> = {
+    common: 'border-gray-500',
+    rare: 'border-blue-500',
+    'super-rare': 'border-purple-500',
+    epic: 'border-orange-500',
+    legend: 'border-yellow-500',
+    'super-legend': 'border-red-500',
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Header stats */}
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">💎 {universalShards} Shards Universels</span>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={selectAllDuplicates}>
+            <RefreshCw className="w-3 h-3 mr-1" />
+            Sélec. doublons
+          </Button>
+          {selectedIds.size > 0 && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowConfirm(true)}
+            >
+              <Trash2 className="w-3 h-3 mr-1" />
+              Recycler {selectedIds.size} (+{totalShards} 💎)
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Confirmation */}
+      {showConfirm && (
+        <div className="rounded-md border border-destructive/50 bg-destructive/10 p-3 space-y-2">
+          <p className="text-sm text-destructive font-medium">
+            Recycler {selectedIds.size} héros pour {totalShards} Shards Universels ?
+          </p>
+          <p className="text-xs text-muted-foreground">Cette action est irréversible.</p>
+          <div className="flex gap-2">
+            <Button variant="destructive" size="sm" onClick={handleConfirmRecycle}>Confirmer</Button>
+            <Button variant="outline" size="sm" onClick={() => setShowConfirm(false)}>Annuler</Button>
+          </div>
+        </div>
+      )}
+
+      {/* Grille de héros */}
+      <div className="grid grid-cols-4 gap-2 max-h-80 overflow-y-auto">
+        {heroes.map(hero => {
+          const selected = selectedIds.has(hero.id);
+          const recycleVal = getRecycleValue(hero);
+          return (
+            <div
+              key={hero.id}
+              className={`relative border-2 rounded-md p-1.5 cursor-pointer transition-all ${
+                rarityColors[hero.rarity] || 'border-gray-500'
+              } ${selected ? 'bg-destructive/20 scale-95' : 'bg-card/50 hover:bg-card'} ${
+                hero.isLocked ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
+              onClick={() => toggleSelect(hero.id)}
+            >
+              <div className="text-xs text-center truncate">{hero.name.split(' #')[0]}</div>
+              <div className="text-xs text-center text-muted-foreground">
+                +{recycleVal}💎
+              </div>
+              {/* Lock button */}
+              <button
+                className="absolute top-0.5 right-0.5 p-0.5 rounded hover:bg-white/10"
+                onClick={e => { e.stopPropagation(); onToggleLock(hero.id); }}
+              >
+                {hero.isLocked
+                  ? <Lock className="w-2.5 h-2.5 text-yellow-400" />
+                  : <Unlock className="w-2.5 h-2.5 text-muted-foreground" />
+                }
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Table des taux */}
+      <div className="text-xs text-muted-foreground border-t pt-2">
+        <span className="font-medium">Taux : </span>
+        Common=1💎 · Rare=3💎 · Super-Rare=8💎 · Epic=20💎 · Legend=50💎 · Super-Legend=150💎
+        <span className="ml-1">(+1💎/10 levels)</span>
+      </div>
+    </div>
+  );
+}

--- a/src/game/recycleSystem.ts
+++ b/src/game/recycleSystem.ts
@@ -1,0 +1,35 @@
+import { Hero, Rarity } from './types';
+
+// Valeur en Universal Shards selon la rareté
+export const RECYCLE_VALUES: Record<Rarity, number> = {
+  common: 1,
+  rare: 3,
+  'super-rare': 8,
+  epic: 20,
+  legend: 50,
+  'super-legend': 150,
+};
+
+// Calcule la valeur d'un héros au recyclage
+export function getRecycleValue(hero: Hero): number {
+  const base = RECYCLE_VALUES[hero.rarity];
+  // Bonus selon le level : +1 shard par tranche de 10 levels
+  const levelBonus = Math.floor(hero.level / 10);
+  return base + levelBonus;
+}
+
+// Calcule la valeur totale d'un lot de héros
+export function getTotalRecycleValue(heroes: Hero[]): number {
+  return heroes.reduce((total, h) => total + getRecycleValue(h), 0);
+}
+
+// Recycle les héros : retourne les IDs supprimés et les shards gagnés
+export function recycleHeroes(
+  heroes: Hero[],
+  idsToRecycle: string[]
+): { remainingHeroes: Hero[]; shardsGained: number } {
+  const toRecycle = heroes.filter(h => idsToRecycle.includes(h.id) && !h.isLocked);
+  const shardsGained = getTotalRecycleValue(toRecycle);
+  const remainingHeroes = heroes.filter(h => !idsToRecycle.includes(h.id) || h.isLocked);
+  return { remainingHeroes, shardsGained };
+}

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -49,6 +49,7 @@ export interface Hero {
   stuckTimer: number;
   icon: string; // icon key for PixelIcon
   progressionStats: HeroProgressionStats;
+  isLocked?: boolean;
 }
 
 export const MAX_LEVEL_BY_RARITY: Record<Rarity, number> = {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -22,12 +22,14 @@ import { spawnEnemy, spawnBoss, tickEnemies, tickBoss, damageEnemiesFromExplosio
 import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
 import { generateShardRewards, applyShardRewards, ShardReward, generateUniversalShardReward } from '@/game/shardRewardSystem';
+import { recycleHeroes } from '@/game/recycleSystem';
+import RecyclePanel from '@/components/RecyclePanel';
 import DailyQuests from '@/components/DailyQuests';
 import Achievements from '@/components/Achievements';
 import XpBar from '@/components/XpBar';
 import PixelIcon from '@/components/PixelIcon';
 import HeroAvatar from '@/components/HeroAvatar';
-import { Home, Users, Sparkles, Swords, Map, Trophy, Coins, Star, ChevronLeft, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Bomb, Lock as LockIcon, Volume2, VolumeX, User, Hammer, ArrowDown } from 'lucide-react';
+import { Home, Users, Sparkles, Swords, Map, Trophy, Coins, Star, ChevronLeft, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Bomb, Lock as LockIcon, Volume2, VolumeX, User, Hammer, ArrowDown, Trash2 } from 'lucide-react';
 import { SFX, isMuted, setMuted } from '@/game/sfx';
 import { toast } from '@/hooks/use-toast';
 
@@ -109,6 +111,7 @@ const Index = () => {
   const [fusionSlots, setFusionSlots] = useState<(Hero | null)[]>([null, null]);
   const [heroPickerOpen, setHeroPickerOpen] = useState(false);
   const [activeSlotIdx, setActiveSlotIdx] = useState<number | null>(null);
+  const [showRecycleMode, setShowRecycleMode] = useState(false);
   const [heroFilters, setHeroFilters] = useState<HeroFilters>(() => {
     if (typeof window === 'undefined') return DEFAULT_HERO_FILTERS;
     try {
@@ -1378,6 +1381,27 @@ const Index = () => {
     }
   };
 
+  const handleRecycle = (ids: string[], shardsGained: number) => {
+    const { remainingHeroes } = recycleHeroes(player.heroes, ids);
+    setPlayer(prev => ({
+      ...prev,
+      heroes: remainingHeroes,
+      universalShards: prev.universalShards + shardsGained,
+    }));
+    if (canWriteCloud) {
+      saveHeroesToCloud(remainingHeroes);
+      removeHeroesFromCloud(ids);
+    }
+    toast({ title: `♻️ Recyclage!`, description: `${ids.length} héros recyclés → +${shardsGained} 💎` });
+  };
+
+  const handleToggleLock = (heroId: string) => {
+    setPlayer(prev => ({
+      ...prev,
+      heroes: prev.heroes.map(h => h.id === heroId ? { ...h, isLocked: !h.isLocked } : h),
+    }));
+  };
+
   const upgradeHeroData = upgradeHeroId ? player.heroes.find(h => h.id === upgradeHeroId) ?? null : null;
 
   const heroRarityOrder: Rarity[] = ['common', 'rare', 'super-rare', 'epic', 'legend', 'super-legend'];
@@ -2130,6 +2154,28 @@ const Index = () => {
                 {filteredHeroes.length} héros affichés sur {player.heroes.length}
               </p>
             </div>
+
+            {/* Toggle mode recyclage */}
+            <div className="flex justify-end mb-2">
+              <button
+                className={`pixel-btn font-pixel text-[8px] flex items-center gap-1 ${showRecycleMode ? 'pixel-btn-primary' : 'pixel-btn-secondary'}`}
+                onClick={() => setShowRecycleMode(r => !r)}
+              >
+                <Trash2 size={12} />
+                {showRecycleMode ? 'Terminer recyclage' : 'Recycler des héros'}
+              </button>
+            </div>
+
+            {showRecycleMode && (
+              <div className="pixel-border bg-card p-3 sm:p-4">
+                <RecyclePanel
+                  heroes={player.heroes}
+                  universalShards={player.universalShards}
+                  onRecycle={handleRecycle}
+                  onToggleLock={handleToggleLock}
+                />
+              </div>
+            )}
 
             {filteredHeroes.length === 0 ? (
               <div className="pixel-border bg-card p-6 text-center space-y-3">


### PR DESCRIPTION
## Summary
- Nouveau système de recyclage : chaque héros peut être converti en Universal Shards
- Taux : 1💎 (Common) à 150💎 (Super-Legend), +1💎 par tranche de 10 levels
- Lock/Unlock des héros pour les protéger du recyclage accidentel
- Sélection rapide des doublons ("Sélec. doublons")
- Confirmation obligatoire avant recyclage
- Cloud save mis à jour (heroes supprimés de la DB)

## Closes
Fixes #148

## Test plan
- [ ] Build passe
- [ ] Tests passent
- [ ] Bouton "Recycler des héros" visible dans l'écran Héros
- [ ] Sélectionner des héros → shards prévisualisés
- [ ] Confirmer → héros supprimés, universalShards crédités
- [ ] Héros lockés ne peuvent pas être sélectionnés
- [ ] "Sélec. doublons" sélectionne les doublons non-lockés

🤖 Generated with [Claude Code](https://claude.com/claude-code)