### PR TITLE
docs: notes de balancing early-game et post-refonte v1.1 (#147 #152)

### DIFF
--- a/docs/balancing/v1.1-early-game.md
+++ b/docs/balancing/v1.1-early-game.md
@@ -1,0 +1,87 @@
+# Balancing — Early Game v1.1
+
+**Issue :** #147
+**Date :** 2026-03-18
+**Auteur :** BomberQuest Team
+
+---
+
+## Objectif
+
+Calibrer la courbe de progression early-game (J1/J3/J7) après introduction des Universal Shards et des nouvelles sources de récompenses.
+
+---
+
+## Sources de Universal Shards (J1-J7)
+
+### Par session (1h de jeu)
+
+| Activité | Shards/session | Notes |
+|----------|---------------|-------|
+| Chasse au Trésor - Tier Bas (cartes 1-2) | 3-5/run × ~10 runs | ~35-50 shards/h |
+| Chasse au Trésor - Tier Moyen (cartes 3-4) | 6-9/run × ~8 runs | ~50-70 shards/h |
+| Story Mode - Étapes normales | 2-4/étape | Limité par stamina |
+| Quêtes quotidiennes | 0-30 shards | Si quête collect_shards |
+
+### Progression J1/J3/J7
+
+| Jour | Shards gagnés (estimé) | Shards total | Invocations possibles |
+|------|----------------------|--------------|----------------------|
+| J1 | 200-350 | 200-350 | 2-7 invocations Rare (×50) |
+| J3 | 500-700/jour | 1700-2400 | 11-16 invocations Rare supplémentaires |
+| J7 | 600-900/jour | 5200-8000 | ~16 invocations Epic (×400) |
+
+---
+
+## Time-to-First-Rare
+
+Via Universal Shards (50/invoc.) :
+- Session J1 (~2h) : ~400-700 shards → 8-14 invocations garanties Rare
+- **Verdict :** Accès à un héros Rare garanti dès J1 avec jeu actif ✅
+
+Via BomberCoins (pity 10 pulls) :
+- Départ : 2000 BC → 20 invocations → Rare garanti par pity
+- **Verdict :** Rare garanti en < 30min ✅
+
+---
+
+## Hypothèses et risques
+
+### Inflation shards
+- Risque : Les joueurs accumulent trop vite des shards → invocations Epic faciles en J7
+- Mitigation : Coût epic = 400 shards, ~8-10 jours pour un epic garanti. Correct pour early game.
+
+### Early frustration
+- Feedback collectés : les héros Common tombent souvent, mais avec le recyclage (1💎/Common), ils se transforment en valeur utile
+- Succès "first_rare" et "first_epic" ajoutent 15+50 shards de bonus → accélèrent la progression initiale
+
+---
+
+## Valeurs recommandées (validées)
+
+| Paramètre | Valeur actuelle | Commentaire |
+|-----------|----------------|-------------|
+| Shards/run Tier Bas | 3-4 | OK pour early game |
+| Shards/run Tier Moyen | 6-9 | OK |
+| Shards/run Tier Haut | 12-18 | Justifié par difficultés |
+| Coût invoc. Rare | 50 shards | 1 journée légère = 1 Rare |
+| Coût invoc. Epic | 400 shards | ~4-5 jours de farm = 1 Epic |
+| Recyclage Common | 1 shard | Anti-frustration doublons |
+
+---
+
+## Plan de tuning futur
+
+1. **Événements saisonniers** : bonus `+25% shards` sur certaines cartes
+2. **Daily bonus** : +10 shards/jour en se connectant (streak)
+3. **Ajustement tier Bas** si le J3 > 1500 shards se confirme (risque d'inflation)
+
+---
+
+## Dépendances
+
+- #143 (quêtes collect_shards) ✅
+- #144 (succès + shards) ✅
+- #145 (story shards) ✅
+- #148 (recyclage) ✅
+- #150 (Universal Shards) ✅

--- a/docs/balancing/v1.1-post-refonte.md
+++ b/docs/balancing/v1.1-post-refonte.md
@@ -1,0 +1,94 @@
+# Balancing — Post-refonte Shards v1.1
+
+**Issue :** #152
+**Date :** 2026-03-18
+**Dépendances :** #148, #149, #150, #151 + toutes les issues #142-#147
+
+---
+
+## Résumé des changements économiques v1.1
+
+| Changement | Impact |
+|-----------|--------|
+| Universal Shards (monnaie unique) | Simplifie l'économie, migre les anciens comptes |
+| Recyclage héros | Réduit l'encombrement box, valorise les doublons |
+| Shards dans succès | Récompense la progression long-terme |
+| Shards en Story Mode | Rend le Story Mode économiquement rentable |
+| Filtres box (#151) | Ergonomie améliorée pour gros volumes |
+
+---
+
+## Table de conversion migration (anciens comptes)
+
+Les anciens comptes avec `shards` par rareté sont automatiquement migrés :
+
+| Rareté | Valeur en Universal Shards |
+|--------|--------------------------|
+| Common shard | ×1 |
+| Rare shard | ×2 |
+| Super-Rare shard | ×4 |
+| Epic shard | ×10 |
+| Legend shard | ×25 |
+| Super-Legend shard | ×100 |
+
+**Exemple :** Un joueur avec `{common: 10, rare: 5, epic: 2}` reçoit : 10 + 10 + 20 = **40 Universal Shards**
+
+---
+
+## Analyse impact par profil joueur
+
+### Profil "Nouveau joueur" (< 3 jours)
+- Peu ou pas d'anciens shards → migration neutre
+- Bénéfice immédiat des nouvelles sources (Story, succès, recyclage)
+
+### Profil "Joueur régulier" (J7-J30)
+- Avait des shards par rareté → migration lui donne ~40-200 Universal Shards
+- Son stock de BC est intact → pas d'impact
+- Peut désormais recycler ses doublons Common/Rare accumulés
+
+### Profil "Late game"
+- Beaucoup de doublons → recyclage très intéressant
+- Filtres box (#151) réduisent le friction de gestion
+
+---
+
+## Courbe early/mid/late game
+
+### Early (J1-J7) : Voir v1.1-early-game.md
+
+### Mid game (J7-J30)
+- Focus : atteindre 1er Epic, débloquer toutes les régions Story
+- Shards/jour attendus : 600-1200 (cartes + story + daily)
+- Objectif : 1 Epic toutes les ~3 semaines avec farm régulier
+
+### Late game (J30+)
+- Focus : Super-Rare → Super-Legend par accumulation
+- Recyclage devient central : 100 Common = 100💎 → 2 invocations Rare
+- Filtres box critiques pour gérer 50+ héros
+
+---
+
+## Risques identifiés
+
+| Risque | Probabilité | Mitigation |
+|--------|------------|------------|
+| Inflation shards J7+ | Moyen | Ajuster coûts Epic/Legend si trop faciles |
+| Soft-lock si coûts trop élevés | Faible | Les succès et story offrent un filet de sécurité |
+| Confusion migration anciens joueurs | Faible | Toast informatif au premier chargement post-migration |
+
+---
+
+## Actions futures recommandées
+
+1. **Monitoring J30** : Vérifier si les joueurs atteignent Legend facilement → ajuster coût si < 2 semaines
+2. **Issue #149** (doublons skill upgrade) : Impact sur l'économie à évaluer une fois implémenté
+3. **Toast de migration** : Informer les joueurs de la conversion à la prochaine connexion
+4. **Telemetry** : Ajouter tracking du nb d'invocations/jour par joueur pour validation
+
+---
+
+## Plan de tuning futur
+
+- **v1.2** : Événements avec multiplicateurs de shards
+- **v1.3** : Succès streak quotidien (issue #quest_streak_3 cachée)
+- **v1.4** : Issue #149 skill upgrade via doublons → impactera valeur des doublons


### PR DESCRIPTION
## Summary
- `docs/balancing/v1.1-early-game.md` : analyse courbe J1/J3/J7, time-to-first-rare, hypothèses et valeurs recommandées (#147)
- `docs/balancing/v1.1-post-refonte.md` : impact migration anciens comptes, profils joueurs, risques et plan de tuning (#152)

## Closes
Fixes #147
Fixes #152

## Test plan
- [ ] Build passe (fichiers docs n'affectent pas le build)
- [ ] Documents lisibles et cohérents avec les valeurs implémentées