### PR TITLE
feat: amélioration compétences via doublons (#149)

### DIFF
--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -18,6 +18,7 @@ export interface Skill {
   description: string;
   trigger: string;
   effect: string;
+  skillLevel?: number; // 1-5, default 1
 }
 
 export interface HeroProgressionStats {

--- a/src/game/upgradeSystem.ts
+++ b/src/game/upgradeSystem.ts
@@ -1,4 +1,4 @@
-import { Hero, HeroStats, Rarity, RARITY_CONFIG, MAX_LEVEL_BY_RARITY } from './types';
+import { Hero, HeroStats, Rarity, Skill, RARITY_CONFIG, MAX_LEVEL_BY_RARITY } from './types';
 
 /** XP required per level (level 1 requires 0 XP, level 2 requires XP_FOR_LEVEL[1], etc.) */
 export const XP_FOR_LEVEL: Record<number, number> = {
@@ -398,4 +398,108 @@ export function isHeroMaxLevel(hero: Hero): boolean {
 /** Count how many duplicates of a given hero's rarity exist (excluding the hero itself) */
 export function countDuplicates(heroes: Hero[], heroId: string, rarity: Rarity): number {
   return heroes.filter(h => h.id !== heroId && h.rarity === rarity).length;
+}
+
+// Coût en nombre de doublons par level de skill (index = level actuel)
+const SKILL_UPGRADE_COST = [0, 1, 2, 3, 5]; // Pour passer du level 1→2, 2→3, 3→4, 4→5
+
+// Niveau max d'un skill selon la rareté du héros
+export const MAX_SKILL_LEVEL_BY_RARITY: Record<Rarity, number> = {
+  common: 1,
+  rare: 2,
+  'super-rare': 3,
+  epic: 4,
+  legend: 5,
+  'super-legend': 5,
+};
+
+// Retourne la description d'un skill avec son niveau si > 1
+export function getSkillDescription(skill: Skill): string {
+  const level = skill.skillLevel || 1;
+  const levelSuffix = level > 1 ? ` (Niveau ${level})` : '';
+  return skill.description + levelSuffix;
+}
+
+// Vérifie si un héros peut avoir un skill amélioré via un doublon
+export function canUpgradeSkill(
+  hero: Hero,
+  skillIndex: number,
+  duplicates: Hero[]
+): { canUpgrade: boolean; reason: string; duplicatesNeeded: number } {
+  if (!hero.skills || hero.skills.length === 0) {
+    return { canUpgrade: false, reason: "Ce héros n'a pas de compétences", duplicatesNeeded: 0 };
+  }
+
+  const skill = hero.skills[skillIndex];
+  if (!skill) {
+    return { canUpgrade: false, reason: 'Compétence introuvable', duplicatesNeeded: 0 };
+  }
+
+  const currentLevel = skill.skillLevel || 1;
+  const maxLevel = MAX_SKILL_LEVEL_BY_RARITY[hero.rarity];
+
+  if (currentLevel >= maxLevel) {
+    return { canUpgrade: false, reason: 'Niveau maximum atteint', duplicatesNeeded: 0 };
+  }
+
+  const needed = SKILL_UPGRADE_COST[currentLevel] || 1;
+  const heroBaseName = hero.name.split(' #')[0];
+  const availableDuplicates = duplicates.filter(
+    d => d.id !== hero.id && d.name.split(' #')[0] === heroBaseName && !d.isLocked
+  ).length;
+
+  if (availableDuplicates < needed) {
+    return {
+      canUpgrade: false,
+      reason: `${needed - availableDuplicates} doublon(s) manquant(s)`,
+      duplicatesNeeded: needed,
+    };
+  }
+
+  return { canUpgrade: true, reason: '', duplicatesNeeded: needed };
+}
+
+// Applique l'upgrade : supprime les doublons consommés, améliore le skill
+export function upgradeSkillWithDuplicate(
+  heroes: Hero[],
+  heroId: string,
+  skillIndex: number
+): { updatedHeroes: Hero[]; success: boolean; message: string; removedIds: string[] } {
+  const hero = heroes.find(h => h.id === heroId);
+  if (!hero) {
+    return { updatedHeroes: heroes, success: false, message: 'Héros introuvable', removedIds: [] };
+  }
+
+  const check = canUpgradeSkill(hero, skillIndex, heroes);
+  if (!check.canUpgrade) {
+    return { updatedHeroes: heroes, success: false, message: check.reason, removedIds: [] };
+  }
+
+  // Trouver les doublons à consommer (même nom de base, non verrouillés)
+  const heroBaseName = hero.name.split(' #')[0];
+  const duplicatesToConsume = heroes
+    .filter(d => d.id !== heroId && d.name.split(' #')[0] === heroBaseName && !d.isLocked)
+    .slice(0, check.duplicatesNeeded);
+
+  const removedIds = duplicatesToConsume.map(d => d.id);
+  const newLevel = (hero.skills[skillIndex].skillLevel || 1) + 1;
+
+  // Améliorer le skill du héros
+  const updatedHero: Hero = {
+    ...hero,
+    skills: hero.skills.map((s, i) =>
+      i === skillIndex ? { ...s, skillLevel: newLevel } : s
+    ),
+  };
+
+  const updatedHeroes = heroes
+    .filter(h => !removedIds.includes(h.id))
+    .map(h => h.id === heroId ? updatedHero : h);
+
+  return {
+    updatedHeroes,
+    success: true,
+    message: `${hero.skills[skillIndex].name} amélioré au niveau ${newLevel}!`,
+    removedIds,
+  };
 }

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,7 @@ import { GameState, Hero, MAP_CONFIGS, PlayerData, RARITY_CONFIG, RARITY_ORDER, 
 import { generateMap, tickGame } from '@/game/engine';
 import { summonHero, generateHero } from '@/game/summoning';
 import { loadPlayerData, savePlayerData, getDefaultPlayerData, saveStoryProgress, loadStoryProgress } from '@/game/saveSystem';
-import { getUpgradeCost, upgradeHero, ascendHero, getAscensionCost, countDuplicates } from '@/game/upgradeSystem';
+import { getUpgradeCost, upgradeHero, ascendHero, getAscensionCost, countDuplicates, upgradeSkillWithDuplicate } from '@/game/upgradeSystem';
 import { trackSummon, trackCombatVictory, trackLevelUp, trackRarityUnlock, trackChestsOpened, trackBossDefeated, trackHeroCount, claimAchievementReward, AchievementDefinition } from '@/game/achievements';
 import { DailyQuestData, loadDailyQuests, saveDailyQuests, generateDailyQuests, updateQuestProgress, ALL_CLAIMED_BONUS, ALL_CLAIMED_XP_BONUS } from '@/game/questSystem';
 import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BossType } from '@/game/storyTypes';
@@ -1397,6 +1397,25 @@ const Index = () => {
       removeHeroesFromCloud(removedIds);
       saveHeroesToCloud([ascended]);
     }
+  };
+
+  const handleSkillUpgrade = (heroId: string, skillIndex: number) => {
+    const result = upgradeSkillWithDuplicate(player.heroes, heroId, skillIndex);
+    if (!result.success) {
+      toast({ title: 'Impossible', description: result.message, variant: 'destructive' });
+      return;
+    }
+    setPlayer(prev => ({
+      ...prev,
+      heroes: result.updatedHeroes,
+    }));
+    if (canWriteCloud) {
+      saveHeroesToCloud(result.updatedHeroes.filter(h => h.id === heroId));
+      if (result.removedIds.length > 0) {
+        removeHeroesFromCloud(result.removedIds);
+      }
+    }
+    toast({ title: '⚡ Compétence améliorée!', description: result.message });
   };
 
   const handleRecycle = (ids: string[], shardsGained: number) => {

--- a/src/test/skillUpgrade.test.ts
+++ b/src/test/skillUpgrade.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from 'vitest';
+import { upgradeSkillWithDuplicate, canUpgradeSkill } from '../game/upgradeSystem';
+import { Hero, Rarity, Skill } from '../game/types';
+
+// Helper pour créer un héros de test
+function makeHero(id: string, name: string, rarity: Rarity, skills: Skill[] = []): Hero {
+  return {
+    id,
+    name: `${name} #${id}`,
+    rarity,
+    level: 1,
+    xp: 0,
+    stars: 0,
+    stats: { pwr: 10, spd: 10, rng: 1, bnb: 1, sta: 100, lck: 5 },
+    skills,
+    currentStamina: 100,
+    maxStamina: 100,
+    isActive: true,
+    houseLevel: 1,
+    position: { x: 0, y: 0 },
+    targetPosition: null,
+    path: [],
+    state: 'idle',
+    bombCooldown: 0,
+    stuckTimer: 0,
+    icon: 'test',
+    progressionStats: {
+      chestsOpened: 0,
+      totalDamageDealt: 0,
+      battlesPlayed: 0,
+      victories: 0,
+      obtainedAt: Date.now(),
+    },
+  };
+}
+
+const baseSkill: Skill = {
+  name: 'Flamme',
+  description: 'Inflige des dégâts de feu',
+  trigger: 'on_hit',
+  effect: 'damage',
+  skillLevel: 1,
+};
+
+describe('canUpgradeSkill', () => {
+  it('échoue si le héros n\'a pas de skills', () => {
+    const hero = makeHero('1', 'Blaze', 'rare');
+    const result = canUpgradeSkill(hero, 0, []);
+    expect(result.canUpgrade).toBe(false);
+    expect(result.reason).toContain('compétences');
+  });
+
+  it('échoue si le skill est introuvable', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const result = canUpgradeSkill(hero, 5, []);
+    expect(result.canUpgrade).toBe(false);
+    expect(result.reason).toBe('Compétence introuvable');
+  });
+
+  it('échoue si le niveau max est atteint (Rare = 2)', () => {
+    const skill: Skill = { ...baseSkill, skillLevel: 2 };
+    const hero = makeHero('1', 'Blaze', 'rare', [skill]);
+    const result = canUpgradeSkill(hero, 0, []);
+    expect(result.canUpgrade).toBe(false);
+    expect(result.reason).toBe('Niveau maximum atteint');
+  });
+
+  it('échoue si pas assez de doublons (besoin de 1, aucun dispo)', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const result = canUpgradeSkill(hero, 0, [hero]);
+    expect(result.canUpgrade).toBe(false);
+    expect(result.duplicatesNeeded).toBe(1);
+  });
+
+  it('réussit si assez de doublons', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const duplicate = makeHero('2', 'Blaze', 'rare');
+    const result = canUpgradeSkill(hero, 0, [hero, duplicate]);
+    expect(result.canUpgrade).toBe(true);
+    expect(result.duplicatesNeeded).toBe(1);
+  });
+});
+
+describe('upgradeSkillWithDuplicate', () => {
+  it('échoue si le héros est introuvable', () => {
+    const result = upgradeSkillWithDuplicate([], 'nonexistent', 0);
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Héros introuvable');
+  });
+
+  it('échoue si le héros n\'a pas de skills', () => {
+    const hero = makeHero('1', 'Blaze', 'rare');
+    const result = upgradeSkillWithDuplicate([hero], '1', 0);
+    expect(result.success).toBe(false);
+  });
+
+  it('échoue si pas assez de doublons', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const result = upgradeSkillWithDuplicate([hero], '1', 0);
+    expect(result.success).toBe(false);
+    expect(result.message).toContain('doublon');
+  });
+
+  it('améliore le skill au niveau 2 et consomme le doublon', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const duplicate = makeHero('2', 'Blaze', 'rare');
+    const result = upgradeSkillWithDuplicate([hero, duplicate], '1', 0);
+
+    expect(result.success).toBe(true);
+    expect(result.removedIds).toContain('2');
+    expect(result.updatedHeroes).toHaveLength(1);
+
+    const upgraded = result.updatedHeroes.find(h => h.id === '1');
+    expect(upgraded?.skills[0].skillLevel).toBe(2);
+  });
+
+  it('consomme le bon nombre de doublons pour passer au niveau 3', () => {
+    const skill: Skill = { ...baseSkill, skillLevel: 2 };
+    // Super-rare peut aller jusqu'à 3, besoin de 2 doublons pour passer de 2→3
+    const hero = makeHero('1', 'Blaze', 'super-rare', [skill]);
+    const dup1 = makeHero('2', 'Blaze', 'super-rare');
+    const dup2 = makeHero('3', 'Blaze', 'super-rare');
+    const result = upgradeSkillWithDuplicate([hero, dup1, dup2], '1', 0);
+
+    expect(result.success).toBe(true);
+    expect(result.removedIds).toHaveLength(2);
+
+    const upgraded = result.updatedHeroes.find(h => h.id === '1');
+    expect(upgraded?.skills[0].skillLevel).toBe(3);
+  });
+
+  it('ne consomme pas les doublons verrouillés', () => {
+    const hero = makeHero('1', 'Blaze', 'rare', [baseSkill]);
+    const lockedDup = { ...makeHero('2', 'Blaze', 'rare'), isLocked: true };
+    const result = upgradeSkillWithDuplicate([hero, lockedDup], '1', 0);
+
+    // Le doublon est verrouillé donc on manque de doublons
+    expect(result.success).toBe(false);
+  });
+
+  it('ne modifie pas les autres skills du héros', () => {
+    const skill2: Skill = { name: 'Glace', description: 'Gèle', trigger: 'on_hit', effect: 'freeze', skillLevel: 1 };
+    const hero = makeHero('1', 'Blaze', 'super-rare', [baseSkill, skill2]);
+    const duplicate = makeHero('2', 'Blaze', 'super-rare');
+    const result = upgradeSkillWithDuplicate([hero, duplicate], '1', 0);
+
+    expect(result.success).toBe(true);
+    const upgraded = result.updatedHeroes.find(h => h.id === '1');
+    expect(upgraded?.skills[0].skillLevel).toBe(2); // amélioré
+    expect(upgraded?.skills[1].skillLevel).toBe(1); // inchangé
+  });
+});


### PR DESCRIPTION
## Summary
- `upgradeSystem.ts` : fonctions `canUpgradeSkill` et `upgradeSkillWithDuplicate`
- Coût : 1-5 doublons selon le niveau actuel du skill
- Niveau max selon rareté (Rare=2, Super-Rare=3, Epic=4, Legend/Super-Legend=5)
- Handler `handleSkillUpgrade` dans Index.tsx avec sync cloud (save + remove)
- Tests unitaires ajoutés (12 tests)

## Closes
Fixes #149

## Test plan
- [x] Build passe
- [x] Tests passent (incluant skillUpgrade.test.ts — 12 tests)
- [x] `canUpgradeSkill` retourne le bon résultat selon rareté, level et doublons disponibles
- [x] `upgradeSkillWithDuplicate` consomme les doublons et améliore le skill
- [x] Les doublons verrouillés sont ignorés
- [x] Les autres skills du héros ne sont pas modifiés

🤖 Generated with [Claude Code](https://claude.com/claude-code)