### PR TITLE
feat: Clan Bomb System - architecture + skins visuels (#169 #167)

### DIFF
--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -2,6 +2,7 @@ import React, { useRef, useEffect, useCallback } from 'react';
 import { GameState } from '@/game/types';
 import { drawHeroSprite } from '@/game/heroRenderer';
 import { drawEnemy, drawBoss } from '@/game/enemyRenderer';
+import { getBombStyle } from '@/game/clanBombSystem';
 
 interface GameGridProps {
   gameState: GameState;
@@ -138,30 +139,45 @@ const GameGrid: React.FC<GameGridProps> = ({ gameState }) => {
       const cx = px + TILE_SIZE / 2;
       const cy = py + TILE_SIZE / 2 + 2;
 
-      ctx.fillStyle = 'rgba(0,0,0,0.4)';
+      const style = getBombStyle(bomb.family);
+
+      // Halo lumineux (uniquement pour les bombes de clan)
+      if (bomb.family) {
+        ctx.fillStyle = style.glowColor;
+        ctx.beginPath();
+        ctx.arc(cx, cy, r * 1.5, 0, Math.PI * 2);
+        ctx.fill();
+      }
+
+      // Shadow
+      ctx.fillStyle = style.shadowColor;
       ctx.beginPath();
       ctx.ellipse(cx, cy + r * 0.7, r * 0.8, r * 0.3, 0, 0, Math.PI * 2);
       ctx.fill();
 
-      ctx.fillStyle = '#222';
+      // Main bomb body
+      ctx.fillStyle = style.bodyColor;
       ctx.beginPath();
       ctx.arc(cx, cy, r, 0, Math.PI * 2);
       ctx.fill();
 
-      ctx.fillStyle = 'rgba(255,255,255,0.15)';
+      // Highlight
+      ctx.fillStyle = style.highlightColor;
       ctx.beginPath();
       ctx.arc(cx - r * 0.3, cy - r * 0.3, r * 0.3, 0, Math.PI * 2);
       ctx.fill();
 
-      ctx.strokeStyle = '#ff8c00';
+      // Fuse
+      ctx.strokeStyle = style.fuseColor;
       ctx.lineWidth = 2;
       ctx.beginPath();
       ctx.moveTo(cx, cy - r);
       ctx.quadraticCurveTo(cx + 5, cy - r - 6, cx + 3, cy - r - 10);
       ctx.stroke();
 
+      // Flame
       if (Math.sin(time / 80) > -0.3) {
-        ctx.fillStyle = '#FFD700';
+        ctx.fillStyle = style.flameColor;
         ctx.beginPath();
         ctx.arc(cx + 3, cy - r - 10, 3, 0, Math.PI * 2);
         ctx.fill();

--- a/src/game/clanBombSystem.ts
+++ b/src/game/clanBombSystem.ts
@@ -1,0 +1,76 @@
+import { HeroFamilyId } from './types';
+
+export interface ClanBombStyle {
+  bodyColor: string;      // Couleur principale de la bombe
+  highlightColor: string; // Reflet/highlight
+  fuseColor: string;      // Couleur de la mèche
+  flameColor: string;     // Couleur de la flamme
+  glowColor: string;      // Couleur du halo (rgba)
+  shadowColor: string;    // Couleur de l'ombre
+}
+
+export const CLAN_BOMB_STYLES: Record<HeroFamilyId, ClanBombStyle> = {
+  'ember-clan': {
+    bodyColor: '#8B1A1A',        // Rouge foncé braise
+    highlightColor: 'rgba(255,100,50,0.3)',
+    fuseColor: '#FF4500',        // Orange-rouge
+    flameColor: '#FF6B1A',
+    glowColor: 'rgba(255,80,0,0.25)',
+    shadowColor: 'rgba(139,26,26,0.5)',
+  },
+  'storm-riders': {
+    bodyColor: '#1A2B5E',        // Bleu électrique foncé
+    highlightColor: 'rgba(100,180,255,0.3)',
+    fuseColor: '#00BFFF',        // Cyan électrique
+    flameColor: '#7DF9FF',
+    glowColor: 'rgba(0,191,255,0.25)',
+    shadowColor: 'rgba(26,43,94,0.5)',
+  },
+  'forge-guard': {
+    bodyColor: '#3D2B1A',        // Marron métal foncé
+    highlightColor: 'rgba(200,140,60,0.3)',
+    fuseColor: '#CD7F32',        // Bronze
+    flameColor: '#FFD700',
+    glowColor: 'rgba(205,127,50,0.25)',
+    shadowColor: 'rgba(61,43,26,0.5)',
+  },
+  'shadow-core': {
+    bodyColor: '#1A0A2E',        // Violet sombre
+    highlightColor: 'rgba(180,100,255,0.3)',
+    fuseColor: '#8A2BE2',        // Violet
+    flameColor: '#DA70D6',
+    glowColor: 'rgba(138,43,226,0.25)',
+    shadowColor: 'rgba(26,10,46,0.5)',
+  },
+  'arcane-circuit': {
+    bodyColor: '#0A2E2E',        // Teal sombre
+    highlightColor: 'rgba(0,255,200,0.3)',
+    fuseColor: '#00CED1',        // Turquoise
+    flameColor: '#40E0D0',
+    glowColor: 'rgba(0,206,209,0.25)',
+    shadowColor: 'rgba(10,46,46,0.5)',
+  },
+  'wild-pack': {
+    bodyColor: '#1A3A0A',        // Vert forêt
+    highlightColor: 'rgba(100,200,50,0.3)',
+    fuseColor: '#6B8E23',        // Vert olive
+    flameColor: '#ADFF2F',
+    glowColor: 'rgba(107,142,35,0.25)',
+    shadowColor: 'rgba(26,58,10,0.5)',
+  },
+};
+
+// Style par défaut si pas de clan
+export const DEFAULT_BOMB_STYLE: ClanBombStyle = {
+  bodyColor: '#222222',
+  highlightColor: 'rgba(255,255,255,0.15)',
+  fuseColor: '#ff8c00',
+  flameColor: '#FFD700',
+  glowColor: 'rgba(255,140,0,0)',
+  shadowColor: 'rgba(0,0,0,0.4)',
+};
+
+export function getBombStyle(family?: HeroFamilyId): ClanBombStyle {
+  if (!family) return DEFAULT_BOMB_STYLE;
+  return CLAN_BOMB_STYLES[family] || DEFAULT_BOMB_STYLE;
+}

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -594,6 +594,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
             timer: 2.0,
             power: hero.stats.pwr,
             team: 'heroes',
+            family: hero.family,
           });
           hero.currentStamina = Math.max(0, hero.currentStamina - 1);
           hero.bombCooldown = 0.5;

--- a/src/game/summoning.ts
+++ b/src/game/summoning.ts
@@ -1,4 +1,4 @@
-import { Hero, Rarity, RARITY_CONFIG, HERO_NAMES, HERO_ICON_KEYS, Skill } from './types';
+import { Hero, Rarity, RARITY_CONFIG, HERO_NAMES, HERO_ICON_KEYS, Skill, HERO_VISUALS, HeroFamilyId } from './types';
 
 let heroIdCounter = Date.now();
 
@@ -46,6 +46,7 @@ export function generateHero(rarity: Rarity): Hero {
   const config = RARITY_CONFIG[rarity];
   const name = HERO_NAMES[Math.floor(Math.random() * HERO_NAMES.length)];
   const icon = HERO_ICON_KEYS[Math.floor(Math.random() * HERO_ICON_KEYS.length)];
+  const family = (HERO_VISUALS[name.toLowerCase()]?.family || undefined) as HeroFamilyId | undefined;
 
   // Random variance ±10%
   const vary = (base: number) => Math.max(1, Math.round(base * (0.9 + Math.random() * 0.2)));
@@ -87,6 +88,7 @@ export function generateHero(rarity: Rarity): Hero {
     bombCooldown: 0,
     stuckTimer: 0,
     icon,
+    family,
     progressionStats: {
       chestsOpened: 0,
       totalDamageDealt: 0,

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -51,6 +51,7 @@ export interface Hero {
   icon: string; // icon key for PixelIcon
   progressionStats: HeroProgressionStats;
   isLocked?: boolean; // Verrouillé : protégé du recyclage accidentel
+  family?: HeroFamilyId; // Clan du héros
 }
 
 export const MAX_LEVEL_BY_RARITY: Record<Rarity, number> = {
@@ -72,6 +73,7 @@ export interface Bomb {
   timer: number;
   power: number;
   team: BombTeam;
+  family?: HeroFamilyId; // Clan du héros qui a placé la bombe
 }
 
 export interface Explosion {


### PR DESCRIPTION
## Summary
- Nouveau `src/game/clanBombSystem.ts` : styles visuels par clan (6 couleurs uniques)
- `Hero.family` et `Bomb.family` ajoutés aux interfaces
- `generateHero()` assigne la famille depuis HERO_VISUALS
- Bomb placement inclut la famille du héros
- `GameGrid.tsx` : bombes colorées selon le clan (halo lumineux pour les bombes de clan)

## Closes
Fixes #169
Fixes #167

## Test plan
- [ ] Build passe
- [ ] Tests passent
- [ ] Nouvelles parties : bombes ember-clan = rouge, storm-riders = bleu, etc.
- [ ] Heroes sans clan : bombe noire classique
- [ ] Halo lumineux visible pour les bombes de clan