### PR TITLE
fix: page noire au clic héros — progressionStats manquant

### DIFF
--- a/src/game/saveSystem.ts
+++ b/src/game/saveSystem.ts
@@ -60,6 +60,7 @@ export function loadPlayerData(): PlayerData {
           ...hero,
           xp: Number.isFinite(Number(hero?.xp)) ? Number(hero.xp) : 0,
           level: Number.isFinite(Number(hero?.level)) ? Math.max(1, Math.min(Number(hero.level), 120)) : 1,
+          progressionStats: hero.progressionStats ?? { chestsOpened: 0, totalDamageDealt: 0, battlesPlayed: 0, victories: 0, obtainedAt: Date.now() },
         }));
       } else {
         parsed.heroes = [];

--- a/src/hooks/useCloudSave.ts
+++ b/src/hooks/useCloudSave.ts
@@ -50,6 +50,9 @@ function rowToHero(row: PlayerHeroRow): Hero {
     state: 'idle',
     bombCooldown: 0,
     stuckTimer: 0,
+    progressionStats: (row as any).progression_stats ?? { chestsOpened: 0, totalDamageDealt: 0, battlesPlayed: 0, victories: 0, obtainedAt: Date.now() },
+    isLocked: (row as any).is_locked ?? false,
+    family: (row as any).family ?? undefined,
   };
 }
 


### PR DESCRIPTION
## Problème

Cliquer sur un héros dans la page Héros provoquait une page noire sur le site live :

```
TypeError: Cannot read properties of undefined (reading 'obtainedAt')
```

## Cause

`progressionStats` est un champ ajouté récemment à l'interface `Hero`. Les héros sauvegardés avant cet ajout (localStorage + Supabase) n'ont pas ce champ. `HeroUpgradeModal` crashait en accédant à `hero.progressionStats.obtainedAt` sans vérification.

## Fix

- **`saveSystem.ts`** : migration `??` dans le `.map()` des héros au chargement localStorage
- **`useCloudSave.ts`** : `rowToHero()` ajoute `progressionStats` avec fallback `{0, 0, 0, 0, Date.now()}`

En bonus, `rowToHero` reconstruit aussi `isLocked` et `family` qui manquaient aussi.

## Validation

- ✅ `npm run build` sans erreur  
- ✅ 48 tests passent