### PR TITLE
fix: shards universels visibles et fonctionnels dans Invocations

### DIFF
--- a/src/pages/Summon.tsx
+++ b/src/pages/Summon.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
@@ -6,7 +6,7 @@ import { useCloudSave } from '@/hooks/useCloudSave';
 import PixelIcon from '@/components/PixelIcon';
 import { Hero, PlayerData, RARITY_CONFIG, Rarity } from '@/game/types';
 import { summonHero, generateHero } from '@/game/summoning';
-import { loadPlayerData, savePlayerData, getDefaultPlayerData } from '@/game/saveSystem';
+import { loadPlayerData, savePlayerData, loadStoryProgress } from '@/game/saveSystem';
 import { trackSummon, trackRarityUnlock, trackHeroCount } from '@/game/achievements';
 import { toast } from '@/hooks/use-toast';
 import { ArrowLeft, Sparkles, Star, Coins, Gem, ArrowRight } from 'lucide-react';
@@ -143,11 +143,20 @@ const HeroRevealCard: React.FC<{ hero: Hero; index: number; total: number }> = (
 const Summon: React.FC = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
-  const { saveHeroesToCloud, canWrite } = useCloudSave();
-  
-  const [player, setPlayer] = useState<PlayerData>(() => 
-    user ? getDefaultPlayerData() : loadPlayerData()
-  );
+  const { loadFromCloud, saveHeroesToCloud, saveStatsToCloud } = useCloudSave(user?.id, Boolean(user));
+
+  const [player, setPlayer] = useState<PlayerData>(loadPlayerData);
+
+  // Sync depuis le cloud au montage pour avoir les vraies ressources (shards, BC)
+  useEffect(() => {
+    if (!user) return;
+    loadFromCloud().then(result => {
+      if (result?.playerData) {
+        setPlayer(result.playerData);
+        savePlayerData(result.playerData);
+      }
+    });
+  }, [user?.id]);
   const [activeTab, setActiveTab] = useState<'coins' | 'shards'>('coins');
   const [selectedShardRarity, setSelectedShardRarity] = useState<Rarity>('rare');
   
@@ -158,7 +167,7 @@ const Summon: React.FC = () => {
   const [lastSummoned, setLastSummoned] = useState<Hero | null>(null);
   const [summonedBatch, setSummonedBatch] = useState<Hero[]>([]);
 
-  const canWriteCloud = Boolean(user && canWrite);
+  const canWriteCloud = Boolean(user);
 
   const handleSummonBC = (type: 'single' | 'x10' | 'x100') => {
     const cost = BC_COSTS[type];
@@ -260,6 +269,7 @@ const Summon: React.FC = () => {
     if (canWriteCloud) {
       const addedHeroes = mergedHeroes.filter(h => !player.heroes.some(existing => existing.id === h.id));
       if (addedHeroes.length > 0) saveHeroesToCloud(addedHeroes);
+      saveStatsToCloud(updatedData, loadStoryProgress(), null as any);
     }
   };
 
@@ -329,6 +339,7 @@ const Summon: React.FC = () => {
     savePlayerData(updatedData);
     if (canWriteCloud) {
       saveHeroesToCloud([newHero]);
+      saveStatsToCloud(updatedData, loadStoryProgress(), null as any);
     }
   };
 


### PR DESCRIPTION
## Résumé

- Correction de la condition inversée dans `useState` (chargeait `getDefaultPlayerData()` pour les users connectés)
- `useCloudSave` recevait aucun argument → cloud save/load complètement cassé sur cette page
- Ajout d'un `useEffect` qui charge depuis Supabase au montage → les shards crédités sont immédiatement visibles
- `saveStatsToCloud` appelé après chaque invocation pour ne plus perdre les shards

## Test plan

- [ ] Se connecter avec `thomasgermain93@gmail.com`
- [ ] Aller sur la page Invocations → vérifier que les shards Supabase sont affichés (17 203)
- [ ] Faire une invocation par shards → vérifier que le solde décrémente et est persisté
- [ ] Recharger la page → vérifier que le solde est toujours correct

Fixes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)