### PR TITLE
fix: restaurer l'accès à la page profil (pseudo, suppression compte)

### DIFF
--- a/src/components/SlimHeader.tsx
+++ b/src/components/SlimHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Coins, Gem, Crown } from 'lucide-react';
+import { Coins, Gem, Crown, User } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import PixelIcon from '@/components/PixelIcon';
 
@@ -10,6 +10,7 @@ interface SlimHeaderProps {
   accountXp?: number;
   xpToNextLevel?: number;
   title?: string;
+  onProfileClick?: () => void;
 }
 
 export function SlimHeader({
@@ -19,6 +20,7 @@ export function SlimHeader({
   accountXp = 0,
   xpToNextLevel = 100,
   title,
+  onProfileClick,
 }: SlimHeaderProps) {
   const xpPercent = xpToNextLevel > 0
     ? Math.min(100, Math.round((accountXp / xpToNextLevel) * 100))
@@ -57,6 +59,15 @@ export function SlimHeader({
             <Gem size={13} style={{ color: 'hsl(var(--game-rarity-rare))' }} />
             <span>{universalShards.toLocaleString('fr-FR')}</span>
           </div>
+          {onProfileClick && (
+            <button
+              onClick={onProfileClick}
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              title="Profil"
+            >
+              <User size={14} />
+            </button>
+          )}
         </div>
       </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1665,6 +1665,7 @@ const Index = () => {
         accountXp={getXpInCurrentLevel(player.xp).currentXp}
         xpToNextLevel={getXpInCurrentLevel(player.xp).xpNeeded}
         title={PAGE_TITLES[page]}
+        onProfileClick={user ? () => navigate("/profile") : undefined}
       />
 
       {/* Container swipeable 5 pages */}


### PR DESCRIPTION
## Problème

Le bouton d'accès à la page `/profile` a été perdu lors de la refonte UI (création du `SlimHeader` qui a remplacé l'ancien header d'`Index.tsx`).

## Fix

- Ajout d'un prop `onProfileClick?: () => void` dans `SlimHeader`
- Bouton `<User />` affiché dans le header uniquement si l'utilisateur est connecté
- `Index.tsx` passe `() => navigate('/profile')` conditionnel sur `user`

La page profil (pseudo, suppression de compte) est à nouveau accessible depuis l'icône utilisateur en haut à droite du header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)