### PR TITLE
fix(M1): 6 bugs critiques — pathfinding, race conditions, shuffle biaisé

### DIFF
--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -83,6 +83,38 @@ export function generateMap(width: number, height: number, blockDensity: number,
   return { width, height, tiles, chests };
 }
 
+type AStarNode = { x: number; y: number; g: number; f: number; parent: AStarNode | null };
+
+function heapPush(heap: AStarNode[], node: AStarNode): void {
+  heap.push(node);
+  let i = heap.length - 1;
+  while (i > 0) {
+    const p = (i - 1) >> 1;
+    if (heap[p].f <= heap[i].f) break;
+    [heap[p], heap[i]] = [heap[i], heap[p]];
+    i = p;
+  }
+}
+
+function heapPop(heap: AStarNode[]): AStarNode {
+  const top = heap[0];
+  const last = heap.pop()!;
+  if (heap.length > 0) {
+    heap[0] = last;
+    let i = 0;
+    while (true) {
+      let s = i;
+      const l = 2 * i + 1, r = 2 * i + 2;
+      if (l < heap.length && heap[l].f < heap[s].f) s = l;
+      if (r < heap.length && heap[r].f < heap[s].f) s = r;
+      if (s === i) break;
+      [heap[i], heap[s]] = [heap[s], heap[i]];
+      i = s;
+    }
+  }
+  return top;
+}
+
 export function findPath(
   map: GameMap,
   from: { x: number; y: number },
@@ -99,31 +131,33 @@ export function findPath(
     return true;
   };
 
-  // Allow walking to own tile even if bomb is there
   if (!isWalkable(to.x, to.y) && !(to.x === from.x && to.y === from.y)) return null;
 
-  const openSet: { x: number; y: number; g: number; f: number; parent: any }[] = [];
+  const heap: AStarNode[] = [];
   const closedSet = new Set<string>();
+  const gScore = new Map<string, number>();
   const h = (a: { x: number; y: number }) => Math.abs(a.x - to.x) + Math.abs(a.y - to.y);
 
-  openSet.push({ x: from.x, y: from.y, g: 0, f: h(from), parent: null });
+  const startKey = `${from.x},${from.y}`;
+  gScore.set(startKey, 0);
+  heapPush(heap, { x: from.x, y: from.y, g: 0, f: h(from), parent: null });
 
-  while (openSet.length > 0) {
-    openSet.sort((a, b) => a.f - b.f);
-    const current = openSet.shift()!;
+  while (heap.length > 0) {
+    const current = heapPop(heap);
     const key = `${current.x},${current.y}`;
+
+    if (closedSet.has(key)) continue;
+    closedSet.add(key);
 
     if (current.x === to.x && current.y === to.y) {
       const path: { x: number; y: number }[] = [];
-      let node: any = current;
+      let node: AStarNode | null = current;
       while (node) {
         path.unshift({ x: node.x, y: node.y });
         node = node.parent;
       }
       return path;
     }
-
-    closedSet.add(key);
 
     for (const [dx, dy] of [[0, -1], [0, 1], [-1, 0], [1, 0]]) {
       const nx = current.x + dx;
@@ -133,13 +167,9 @@ export function findPath(
       if (!isWalkable(nx, ny) || closedSet.has(nKey)) continue;
 
       const g = current.g + 1;
-      const existing = openSet.find(n => n.x === nx && n.y === ny);
-      if (!existing) {
-        openSet.push({ x: nx, y: ny, g, f: g + h({ x: nx, y: ny }), parent: current });
-      } else if (g < existing.g) {
-        existing.g = g;
-        existing.f = g + h({ x: nx, y: ny });
-        existing.parent = current;
+      if (g < (gScore.get(nKey) ?? Infinity)) {
+        gScore.set(nKey, g);
+        heapPush(heap, { x: nx, y: ny, g, f: g + h({ x: nx, y: ny }), parent: current });
       }
     }
   }

--- a/src/game/questSystem.ts
+++ b/src/game/questSystem.ts
@@ -100,6 +100,14 @@ const QUEST_TEMPLATES: {
   },
 ];
 
+function fisherYatesSeeded<T>(arr: T[], rng: () => number): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 function getTodayString(): string {
   return new Date().toISOString().split('T')[0];
 }
@@ -126,7 +134,7 @@ export function generateDailyQuests(): DailyQuestData {
   const rng = seededRandom(dateToSeed(today));
 
   // Mélanger les templates de façon déterministe
-  const shuffled = [...QUEST_TEMPLATES].sort(() => rng() - 0.5);
+  const shuffled = fisherYatesSeeded([...QUEST_TEMPLATES], rng);
 
   // Assure au moins une quête de farm, une de combat, une de progression
   const farmQuests = shuffled.filter(t => ['complete_maps', 'open_chests', 'earn_coins'].includes(t.type));

--- a/src/game/summoning.ts
+++ b/src/game/summoning.ts
@@ -72,6 +72,14 @@ export function rollRarity(pityCounters: { rare: number; superRare: number; epic
   return 'common';
 }
 
+function fisherYates<T>(arr: T[]): T[] {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
 export function generateHero(rarity: Rarity): Hero {
   const config = RARITY_CONFIG[rarity];
   const name = HERO_NAMES[Math.floor(Math.random() * HERO_NAMES.length)];
@@ -93,7 +101,7 @@ export function generateHero(rarity: Rarity): Hero {
   // Pick skills
   const skillPool = SKILL_POOL_BY_RARITY[rarity];
   const numSkills = config.skills;
-  const shuffled = [...skillPool].sort(() => Math.random() - 0.5);
+  const shuffled = fisherYates([...skillPool]);
   const skills = shuffled.slice(0, numSkills).map(k => ALL_SKILLS[k]);
 
   const id = `hero_${heroIdCounter++}`;

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -174,7 +174,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -295,7 +295,9 @@ const Index = () => {
       }
     };
 
+    let cancelled = false;
     loadWithRetry().then(data => {
+      if (cancelled) return;
       const today = new Date().toISOString().split('T')[0];
       if (data) {
         setPlayer(data.playerData);
@@ -313,14 +315,16 @@ const Index = () => {
       }
       cloudLoadedRef.current = true;
     }).catch((err) => {
+      if (cancelled) return;
       const error = err as Error & { code?: string };
       console.error('CLOUD_LOAD_UNEXPECTED_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
       setCloudValidated(false);
       cloudLoadedRef.current = true;
       toast({ title: 'Cloud indisponible', description: 'Impossible de charger la sauvegarde. Réessaie.', duration: 4000 });
     }).finally(() => {
-      setIsCloudLoading(false);
+      if (!cancelled) setIsCloudLoading(false);
     });
+    return () => { cancelled = true; };
   }, [user?.id, cloudSessionReady, loadFromCloud]);
 
   // Calculate account level from XP
@@ -770,7 +774,7 @@ const Index = () => {
       setGameState(null);
       setScreen('hub');
     }
-  }, [gameState, selectedMap, selectedHeroes]);
+  }, [gameState, selectedMap]);
 
   const endTreasureHunt = () => collectAndContinue(false);
 
@@ -780,7 +784,7 @@ const Index = () => {
       const timer = setTimeout(() => collectAndContinue(true), 1500);
       return () => clearTimeout(timer);
     }
-  }, [autoFarm, gameState?.mapCompleted, collectAndContinue]);
+  }, [autoFarm, gameState?.mapCompleted, gameState?.isStoryMode, collectAndContinue]);
 
   // MERGE_RECIPES is now declared at module level (above) to prevent TDZ crash
 


### PR DESCRIPTION
## Milestone M1 — Bugs critiques & correctifs urgents

Ferme les issues : #285 #286 #287 #288 #289 #290

## Changements

### #285 — Pathfinding A* avec sort() O(n log n) par itération (`engine.ts`)
- Implémentation d'un **min-heap** (`heapPush`/`heapPop`) en O(log n)
- Ajout d'un `Map<string, number>` (`gScore`) pour les lookups de coût en O(1) au lieu de `openSet.find()` O(n)
- Le pattern lazy-deletion (vérification `closedSet.has(key)` en tête de boucle) gère les doublons inhérents au heap

### #286 — Race condition dans le chargement cloud (`Index.tsx`)
- Ajout d'un flag `cancelled` dans le cleanup du `useEffect`
- Les callbacks `.then/.catch/.finally` vérifient `if (cancelled) return` avant d'appliquer les données

### #287 — Stale closure avec Set dans useCallback (`Index.tsx`)
- Suppression de `selectedHeroes` des dépendances de `collectAndContinue` (n'était pas utilisé dans le callback)

### #288 — Algorithme de shuffle biaisé (`summoning.ts`, `questSystem.ts`)
- Remplacement de `.sort(() => Math.random() - 0.5)` par **Fisher-Yates** dans `summoning.ts`
- Ajout de `fisherYatesSeeded(arr, rng)` dans `questSystem.ts` pour conserver le caractère déterministe des quêtes journalières

### #289 — Race condition use-toast.ts — listeners dupliqués (`use-toast.ts`)
- Correction de `useEffect(..., [state])` → `useEffect(..., [])` pour éviter l'accumulation de listeners à chaque re-render

### #290 — Dépendance manquante useEffect auto-farm (`Index.tsx`)
- Ajout de `gameState?.isStoryMode` dans le tableau de dépendances du useEffect auto-farm

## Test plan
- [ ] Build sans erreur TypeScript ✅ (`npm run build`)
- [ ] Lancer une Chasse au Trésor, vérifier que les héros naviguent correctement (pathfinding A*)
- [ ] Activer l'auto-farm, changer de mode (Story/Treasure) et vérifier que le timer se nettoie
- [ ] Vérifier que les toasts s'affichent une seule fois sans accumulation
- [ ] Vérifier que le chargement cloud ne corrompt pas les données en cas de reconnexion rapide
- [ ] Vérifier la distribution des skills sur plusieurs invocations (gacha plus équitable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)