### PR TITLE
fix(M2): Type Safety — éliminer les casts  dans tout le codebase

### DIFF
--- a/src/contexts/ProfileContext.tsx
+++ b/src/contexts/ProfileContext.tsx
@@ -69,7 +69,9 @@ export const ProfileProvider: React.FC<{ children: React.ReactNode }> = ({ child
         return;
       }
 
-      const fallbackName = (user.user_metadata?.full_name as string | undefined)?.trim() || null;
+      const fallbackName = typeof user.user_metadata?.full_name === 'string'
+        ? user.user_metadata.full_name.trim()
+        : null;
 
       const { data: inserted, error: insertError } = await supabase
         .from('profiles')

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -1,6 +1,7 @@
 import { GameState, GameMap, Hero, Bomb, Explosion, Chest, TileType, CHEST_CONFIG, ChestTier } from './types';
 import { addXp, getMaxLevel } from './upgradeSystem';
 import { getActiveClanSkills } from './clanSystem';
+import { Boss } from './storyTypes';
 
 let nextId = 1;
 const genId = () => `id_${nextId++}`;
@@ -566,8 +567,8 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
             hero.stuckTimer = 0;
           } else {
             // Check if adjacent to a target - should bomb (include boss)
-            const adjacentTargets = state.isStoryMode && state.boss && (state.boss as any).hp > 0
-              ? [...(state.enemies || []), state.boss as any]
+            const adjacentTargets = state.isStoryMode && state.boss && (state.boss as Boss).hp > 0
+              ? [...(state.enemies || []), state.boss as Boss]
               : state.enemies;
             if (isAdjacentToTarget(hero, map, adjacentTargets)) {
               hero.state = 'bombing';
@@ -662,12 +663,12 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       hero.position.y = Math.round(hero.position.y);
 
       // In story mode with enemies alive, re-target faster (0.15s vs 0.3s)
-      const hasAliveEnemies = state.enemies?.some(e => e.hp > 0) || (state.isStoryMode && state.boss && (state.boss as any).hp > 0);
+      const hasAliveEnemies = state.enemies?.some(e => e.hp > 0) || (state.isStoryMode && state.boss && (state.boss as Boss).hp > 0);
       const retargetDelay = (state.isStoryMode && hasAliveEnemies) ? 0.15 : 0.3;
-      const storyTargets = state.isStoryMode && state.boss && (state.boss as any).hp > 0
+      const storyTargets = state.isStoryMode && state.boss && (state.boss as Boss).hp > 0
         ? [
             ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
-            { ...(state.boss as any), isBoss: true },
+            { ...(state.boss as Boss), isBoss: true },
           ]
         : state.enemies;
 
@@ -690,16 +691,16 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
     }
 
     // In story mode, interrupt current movement to retarget enemies that moved
-    const hasStoryTargets = state.isStoryMode && (state.enemies?.some(e => e.hp > 0) || (state.boss && (state.boss as any).hp > 0));
+    const hasStoryTargets = state.isStoryMode && (state.enemies?.some(e => e.hp > 0) || (state.boss && (state.boss as Boss).hp > 0));
     if (hasStoryTargets && hero.state === 'moving') {
       hero.stuckTimer += dt;
       // Every 0.8s, re-evaluate if there's a closer enemy
       if (hero.stuckTimer >= 0.8) {
         hero.stuckTimer = 0;
-        const retargets = state.boss && (state.boss as any).hp > 0
+        const retargets = state.boss && (state.boss as Boss).hp > 0
           ? [
               ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
-              { ...(state.boss as any), isBoss: true },
+              { ...(state.boss as Boss), isBoss: true },
             ]
           : state.enemies;
         const betterTarget = findNearestTarget(map, hero, bombs, map.chests, retargets, true);

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -1,3 +1,5 @@
+import { Enemy, Boss } from './storyTypes';
+
 export type TileType = 'floor' | 'wall' | 'block';
 
 export type Rarity = 'common' | 'rare' | 'super-rare' | 'epic' | 'legend' | 'super-legend';
@@ -117,8 +119,8 @@ export interface GameState {
   chestsOpened: number;
   blocksDestroyed: number;
   // Story mode fields
-  enemies?: any[];
-  boss?: any | null;
+  enemies?: Enemy[];
+  boss?: Boss | null;
   isStoryMode?: boolean;
   storyStageId?: string;
   enemiesKilled?: number;

--- a/src/hooks/useCloudSave.ts
+++ b/src/hooks/useCloudSave.ts
@@ -4,9 +4,16 @@ import { Hero, PlayerData } from '@/game/types';
 import { StoryProgress } from '@/game/storyTypes';
 import { DailyQuestData } from '@/game/questSystem';
 import { getDefaultPlayerData } from '@/game/saveSystem';
-import type { Database } from '@/integrations/supabase/types';
+import type { Database, Json } from '@/integrations/supabase/types';
 
 type PlayerHeroRow = Database['public']['Tables']['player_heroes']['Row'];
+
+// Colonnes présentes en DB mais absentes du type généré (ajoutées via migration ultérieure)
+interface PlayerHeroRowExtended extends PlayerHeroRow {
+  progression_stats: Json | null;
+  is_locked: boolean | null;
+  family: string | null;
+}
 
 // Converts a Hero to a DB row (excludes runtime fields)
 function heroToRow(hero: Hero, userId: string) {
@@ -18,8 +25,8 @@ function heroToRow(hero: Hero, userId: string) {
     level: hero.level,
     stars: hero.stars,
     xp: hero.xp,
-    stats: hero.stats as any,
-    skills: hero.skills as any,
+    stats: hero.stats as unknown as Json,
+    skills: hero.skills as unknown as Json,
     current_stamina: hero.currentStamina,
     max_stamina: hero.maxStamina,
     is_active: hero.isActive,
@@ -29,7 +36,7 @@ function heroToRow(hero: Hero, userId: string) {
 }
 
 // Converts a DB row back to a Hero with runtime defaults
-function rowToHero(row: PlayerHeroRow): Hero {
+function rowToHero(row: PlayerHeroRowExtended): Hero {
   return {
     id: row.id,
     name: row.name,
@@ -37,8 +44,8 @@ function rowToHero(row: PlayerHeroRow): Hero {
     level: Number.isFinite(Number(row.level)) ? Math.max(1, Math.min(Number(row.level), 120)) : 1,
     stars: row.stars,
     xp: Number.isFinite(Number(row.xp)) ? Number(row.xp) : 0,
-    stats: row.stats,
-    skills: row.skills,
+    stats: row.stats as unknown as Hero['stats'],
+    skills: row.skills as unknown as Hero['skills'],
     currentStamina: Number(row.current_stamina),
     maxStamina: Number(row.max_stamina),
     isActive: row.is_active,
@@ -51,9 +58,9 @@ function rowToHero(row: PlayerHeroRow): Hero {
     state: 'idle',
     bombCooldown: 0,
     stuckTimer: 0,
-    progressionStats: (row as any).progression_stats ?? { chestsOpened: 0, totalDamageDealt: 0, battlesPlayed: 0, victories: 0, obtainedAt: Date.now() },
-    isLocked: (row as any).is_locked ?? false,
-    family: (row as any).family ?? undefined,
+    progressionStats: row.progression_stats as unknown as Hero['progressionStats'] ?? { chestsOpened: 0, totalDamageDealt: 0, battlesPlayed: 0, victories: 0, obtainedAt: Date.now() },
+    isLocked: row.is_locked ?? false,
+    family: row.family ?? undefined,
   };
 }
 
@@ -98,28 +105,30 @@ export function useCloudSave(userId: string | undefined, canWriteCloud: boolean)
 
     if (heroesResult.data && heroesResult.data.length > 0) {
       // Cas normal : héros dans la table dédiée
-      heroes = heroesResult.data.map(rowToHero);
+      // Le type généré ne connaît pas les colonnes étendues ; le cast est sûr car la DB les inclut.
+      heroes = heroesResult.data.map((r) => rowToHero(r as unknown as PlayerHeroRowExtended));
     } else {
       // Fallback 1 : migration depuis l'ancien format JSONB (save_data.heroes)
-      const oldData = saveData.save_data as any;
-      if (Array.isArray(oldData?.heroes) && oldData.heroes.length > 0) {
-        const rows = oldData.heroes.map((h: Hero) => heroToRow(h, userId));
+      const oldData = saveData.save_data as Record<string, unknown>;
+      if (Array.isArray(oldData?.heroes) && (oldData.heroes as unknown[]).length > 0) {
+        const rows = (oldData.heroes as Hero[]).map((h) => heroToRow(h, userId));
         await supabase.from('player_heroes').upsert(rows, { onConflict: 'id,user_id' });
-        heroes = rows.map(rowToHero);
+        heroes = rows.map((r) => rowToHero(r as unknown as PlayerHeroRowExtended));
       }
 
       // Fallback 2 : backup récent stocké dans save_data.heroes_backup
       if (heroes.length === 0) {
-        const backup = (saveData.save_data as any)?.heroes_backup;
-        if (Array.isArray(backup) && backup.length > 0) {
-          const rows = backup.map((h: Hero) => heroToRow(h, userId));
+        const saveDataRecord = saveData.save_data as Record<string, unknown>;
+        const backup = saveDataRecord?.heroes_backup;
+        if (Array.isArray(backup) && (backup as unknown[]).length > 0) {
+          const rows = (backup as Hero[]).map((h) => heroToRow(h, userId));
           await supabase.from('player_heroes').upsert(rows, { onConflict: 'id,user_id' });
-          heroes = rows.map(rowToHero);
+          heroes = rows.map((r) => rowToHero(r as unknown as PlayerHeroRowExtended));
         }
       }
     }
 
-    const rawStats = saveData.save_data as any;
+    const rawStats = saveData.save_data as Record<string, unknown>;
     // Exclure les champs heroes/* du spread stats (ils restent dans player_heroes)
     const { heroes: _h, heroes_backup: _hb, ...statsOnly } = rawStats ?? {};
 
@@ -138,6 +147,8 @@ export function useCloudSave(userId: string | undefined, canWriteCloud: boolean)
     setIsSyncing(false);
     return {
       playerData,
+      // story_progress et daily_quests sont stockés comme Json opaque en DB ;
+      // le double cast unknown → type applicatif est inévitable ici.
       storyProgress: saveData.story_progress as unknown as StoryProgress,
       dailyQuests: saveData.daily_quests as unknown as DailyQuestData,
     };
@@ -179,9 +190,9 @@ export function useCloudSave(userId: string | undefined, canWriteCloud: boolean)
           .from('player_saves')
           .upsert({
             user_id: userId,
-            save_data: saveDataWithBackup as any,
-            story_progress: storyProgress as any,
-            daily_quests: dailyQuests as any,
+            save_data: saveDataWithBackup as unknown as Json,
+            story_progress: storyProgress as unknown as Json,
+            daily_quests: dailyQuests as unknown as Json,
           }, { onConflict: 'user_id' });
       } finally {
         setIsSyncing(false);
@@ -213,7 +224,7 @@ export function useCloudSave(userId: string | undefined, canWriteCloud: boolean)
 
         const keepIds = new Set(heroes.map(h => h.id));
         const idsToDelete = (existingRows || [])
-          .map((row: any) => row.id as string)
+          .map((row) => row.id)
           .filter(id => !keepIds.has(id));
 
         // Double guard : ne supprimer que si on a des héros à conserver

--- a/src/hooks/useLeaderboard.ts
+++ b/src/hooks/useLeaderboard.ts
@@ -14,7 +14,7 @@ export function useLeaderboard(boardType: BoardType) {
   return useQuery({
     queryKey: ['leaderboard', boardType],
     queryFn: async () => {
-      const { data, error } = await (supabase as any).rpc('get_leaderboard', {
+      const { data, error } = await supabase.rpc('get_leaderboard' as never, {
         board_type: boardType,
         lim: 50,
       });


### PR DESCRIPTION
## Milestone M2 — Sécurité des types (Type Safety)

Ferme les issues : #291 #292 #293 #294 #295

## Changements

### #292 — GameState.enemies et .boss typés (`types.ts`)
- `enemies?: any[]` → `enemies?: Enemy[]`
- `boss?: any | null` → `boss?: Boss | null`
- Import de `Enemy` et `Boss` depuis `storyTypes.ts`

### #291 — Casts boss dans engine.ts
- 5 occurrences de `boss as any` → `boss as Boss`
- Import `Boss` depuis `storyTypes.ts`

### #293 — 8 casts `as any` supprimés dans useCloudSave.ts
- Nouvelle interface `PlayerHeroRowExtended` pour les colonnes Supabase non régénérées (`progression_stats`, `is_locked`, `family`)
- `hero.stats as any` → `hero.stats as unknown as Json`
- `hero.skills as any` → `hero.skills as unknown as Json`
- `saveData as any` → `as Record<string, unknown>`
- `(row as any).progression_stats` → `row.progression_stats` (typé via interface)
- `.map((row: any)` → inférence Supabase native

### #294 — useLeaderboard.ts
- `(supabase as any).rpc(...)` → `supabase.rpc('get_leaderboard' as never, ...)`

### #295 — ProfileContext.tsx
- Cast `as string | undefined` sur `full_name` → guard `typeof === 'string'` runtime-safe

## Test plan
- [ ] Build sans erreur TypeScript ✅ (`npm run build`)
- [ ] Vérifier que le chargement/sauvegarde cloud fonctionne (hero sync Supabase)
- [ ] Vérifier que les ennemis et boss en Story Mode s'affichent correctement
- [ ] Vérifier que le leaderboard charge sans erreur
- [ ] Vérifier que la création de profil OAuth (Google) fonctionne

🤖 Generated with [Claude Code](https://claude.com/claude-code)