### PR TITLE
fix(M3): Code mort & nettoyage — hooks, variables CSS, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,8 +60,7 @@ bomberquest/
 │   │   └── AuthContext.tsx # Supabase auth context (signUp, signIn, signOut)
 │   ├── hooks/
 │   │   ├── useCloudSave.ts # Hybrid save: Supabase + localStorage
-│   │   ├── use-toast.ts    # Toast notifications (Sonner)
-│   │   └── use-mobile.ts   # Mobile breakpoint detection
+│   │   └── use-toast.ts    # Toast notifications (Sonner)
 │   ├── integrations/
 │   │   └── supabase/       # Supabase client and generated types
 │   ├── data/
@@ -148,7 +147,7 @@ The integration client at `src/integrations/supabase/client.ts` also accepts `VI
 | `PascalCase` | React components, TypeScript types/interfaces |
 | `camelCase` | Variables, functions, hook return values |
 | `UPPER_SNAKE_CASE` | Constants (e.g., `RARITY_CONFIG`, `MAP_CONFIGS`) |
-| `use` prefix | Custom hooks (`useCloudSave`, `use-mobile`) |
+| `use` prefix | Custom hooks (`useCloudSave`, `use-toast`) |
 | `draw` prefix | Canvas rendering functions (`drawHero`, `drawTile`) |
 | `spawn` prefix | Entity factory functions (`spawnEnemy`, `spawnBoss`) |
 | `tick` prefix | Per-frame update functions (`tickGame`, `tickBoss`) |

--- a/src/index.css
+++ b/src/index.css
@@ -56,15 +56,6 @@
     --game-rarity-super-legend: 300 100% 70%;
     --game-explosion: 25 100% 55%;
 
-    --sidebar-background: 230 25% 12%;
-    --sidebar-foreground: 0 0% 95%;
-    --sidebar-primary: 348 80% 58%;
-    --sidebar-primary-foreground: 0 0% 100%;
-    --sidebar-accent: 230 20% 18%;
-    --sidebar-accent-foreground: 0 0% 95%;
-    --sidebar-border: 230 20% 22%;
-    --sidebar-ring: 348 80% 58%;
-
     /* Layout nav */
     --bottom-nav-h: 4rem;      /* 64px — hauteur BottomNav mobile */
     --header-h: 3rem;           /* 48px — hauteur SlimHeader */

--- a/src/lib/animations.ts
+++ b/src/lib/animations.ts
@@ -1,4 +1,4 @@
-import { type Variants, type Transition, useReducedMotion } from 'framer-motion';
+import { type Variants, type Transition } from 'framer-motion';
 
 // --- Transition presets ---
 export const SPRING_SNAPPY: Transition = { type: 'spring', stiffness: 350, damping: 30 };
@@ -57,16 +57,3 @@ export const staggerItem: Variants = {
   visible: { opacity: 1, x: 0, transition: TWEEN_NORMAL },
 };
 
-/** Hook prefers-reduced-motion */
-export function usePixelMotion() {
-  const prefersReduced = useReducedMotion();
-  return {
-    transition: prefersReduced ? { duration: 0 } : undefined,
-    safeVariants: <T extends Variants>(v: T): T =>
-      prefersReduced
-        ? Object.fromEntries(
-            Object.entries(v).map(([k, val]) => [k, { ...val, transition: { duration: 0 } }])
-          ) as T
-        : v,
-  };
-}


### PR DESCRIPTION
## Milestone M3 — Code mort & nettoyage

Ferme les issues : #296 #297 #298 #299

## Changements

### #296 — Supprimer usePixelMotion() (`animations.ts`)
- Suppression du hook `usePixelMotion()` jamais importé dans le codebase
- Retrait de l'import `useReducedMotion` devenu inutile

### #297 — Supprimer les variables CSS orphelines (`index.css`)
- Suppression des 8 variables `--sidebar-*` (background, foreground, primary, primary-foreground, accent, accent-foreground, border, ring) — aucune référence trouvée dans le code
- Note : `--game-energy-low` et `--game-xp-blue` sont **conservées** car utilisées dans `HeroCard.tsx` et `HeroUpgradeModal.tsx` (l'issue était incorrecte sur ce point)

### #298 — Corriger CLAUDE.md (`CLAUDE.md`)
- Suppression de la ligne `use-mobile.ts # Mobile breakpoint detection` (fichier inexistant)
- Correction de la convention naming `use` prefix : `use-mobile` → `use-toast`

### #299 — farmStats (`Index.tsx`)
- Aucune modification nécessaire : `farmStats` est déjà affiché dans l'UI (ligne 2390, composant auto-farm actif)
- Issue fermée avec commentaire explicatif

## Test plan
- [ ] Build sans erreur TypeScript ✅ (`npm run build`)
- [ ] Vérifier que les animations Framer Motion fonctionnent encore (pixelPop, stagger, etc.)
- [ ] Vérifier que les barres d'XP et d'énergie dans HeroCard s'affichent correctement (variables CSS conservées)
- [ ] Vérifier que l'auto-farm affiche bien les stats de run

🤖 Generated with [Claude Code](https://claude.com/claude-code)