### PR TITLE
perf(M4): Performance — dedup clan bonus, hero picker, achievements

### DIFF
--- a/src/components/Achievements.tsx
+++ b/src/components/Achievements.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { motion } from 'framer-motion';
 import { AchievementState, AchievementDefinition, ACHIEVEMENTS } from '@/game/achievements';
 import { getUnlockedAchievements, getInProgressAchievements, getLockedAchievements } from '@/game/achievements';
@@ -127,13 +127,14 @@ const AchievementItem: React.FC<AchievementItemProps> = ({ achievement, progress
 const Achievements: React.FC<AchievementsProps> = ({ achievements, onClose, onClaimReward, onClaimAll }) => {
   const [activeTab, setActiveTab] = useState('all');
 
-  const unlocked = getUnlockedAchievements(achievements);
-  const inProgress = getInProgressAchievements(achievements);
-  const locked = getLockedAchievements(achievements);
-
-  const claimableIds = ACHIEVEMENTS
-    .filter(a => achievements[a.id]?.unlocked && !achievements[a.id]?.claimedAt)
-    .map(a => a.id);
+  const { unlocked, inProgress, locked, claimableIds } = useMemo(() => ({
+    unlocked: getUnlockedAchievements(achievements),
+    inProgress: getInProgressAchievements(achievements),
+    locked: getLockedAchievements(achievements),
+    claimableIds: ACHIEVEMENTS
+      .filter(a => achievements[a.id]?.unlocked && !achievements[a.id]?.claimedAt)
+      .map(a => a.id),
+  }), [achievements]);
 
   const renderAchievements = (list: AchievementDefinition[], emptyMessage: string, emptyDescription?: string) => {
     if (list.length === 0) {

--- a/src/components/HeroPickerModal.tsx
+++ b/src/components/HeroPickerModal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -51,10 +51,13 @@ const HeroPickerModal: React.FC<HeroPickerModalProps> = ({
     return { hero, isEligible: true, reason: '' };
   };
 
-  const eligibleHeroes = heroes.filter(h => getEligibility(h).isEligible);
-  const ineligibleHeroes = heroes.filter(h => !getEligibility(h).isEligible);
-
-  const sortedHeroes = [...eligibleHeroes, ...ineligibleHeroes];
+  const { eligibleHeroes, ineligibleHeroes, sortedHeroes } = useMemo(() => {
+    const eligible: Hero[] = [], ineligible: Hero[] = [];
+    for (const h of heroes) {
+      (getEligibility(h).isEligible ? eligible : ineligible).push(h);
+    }
+    return { eligibleHeroes: eligible, ineligibleHeroes: ineligible, sortedHeroes: [...eligible, ...ineligible] };
+  }, [heroes, requiredRarity, alreadySelectedIds]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -1,10 +1,39 @@
 import { GameState, GameMap, Hero, Bomb, Explosion, Chest, TileType, CHEST_CONFIG, ChestTier } from './types';
 import { addXp, getMaxLevel } from './upgradeSystem';
-import { getActiveClanSkills } from './clanSystem';
+import { getActiveClanSkills, ClanSkillEffect } from './clanSystem';
 import { Boss } from './storyTypes';
 
 let nextId = 1;
 const genId = () => `id_${nextId++}`;
+
+// --- Helpers locaux (non exportés) ---
+
+/**
+ * Retourne la somme des bonus d'un type d'effet de clan skill donné.
+ * Evite de répéter getActiveClanSkills().filter().reduce() à chaque appel.
+ */
+function getClanBonus(effectType: ClanSkillEffect['type'], heroes: Hero[]): number {
+  return getActiveClanSkills(heroes)
+    .filter(s => s.effect.type === effectType)
+    .reduce((acc, s) => acc + s.effect.value, 0);
+}
+
+/**
+ * Construit la liste des cibles Story (ennemis + éventuellement boss) normalisée
+ * avec la propriété isBoss. Utilisée par les deux appels à findNearestTarget dans tickGame.
+ */
+function buildStoryTargets(
+  state: Pick<GameState, 'enemies' | 'boss' | 'isStoryMode'>
+): { position: { x: number; y: number }; hp: number; isBoss?: boolean }[] | undefined {
+  if (!state.isStoryMode) return state.enemies;
+  if (state.boss && (state.boss as any).hp > 0) {
+    return [
+      ...(state.enemies || []).map(e => ({ ...e, isBoss: false as const })),
+      { ...(state.boss as any), isBoss: true as const },
+    ];
+  }
+  return state.enemies;
+}
 
 const XP_REWARDS = {
   bombPlaced: 5,
@@ -456,10 +485,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
         chest.hp = Math.max(0, chest.hp - bomb.power);
         if (chest.hp <= 0) {
           // Bonus coin_bonus (shadow-core clan skill)
-          const activeSkillsForCoins = getActiveClanSkills(heroes);
-          const coinBonus = activeSkillsForCoins
-            .filter(s => s.effect.type === 'coin_bonus')
-            .reduce((acc, s) => acc + s.effect.value, 0);
+          const coinBonus = getClanBonus('coin_bonus', heroes);
           coinsEarned += Math.round(chest.reward * (1 + coinBonus));
           chestsOpened++;
           eventLog.push(`Coffre ${chest.tier} ouvert! +${chest.reward} BC`);
@@ -610,10 +636,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
         }
       } else {
         // Bonus move_speed (wild-pack clan skill)
-        const activeSkillsForSpeed = getActiveClanSkills(heroes);
-        const speedBonus = activeSkillsForSpeed
-          .filter(s => s.effect.type === 'move_speed')
-          .reduce((acc, s) => acc + s.effect.value, 0);
+        const speedBonus = getClanBonus('move_speed', heroes);
         const speed = hero.stats.spd * (hero.currentStamina < hero.maxStamina * 0.5 ? 0.75 : 1.0) * (1 + speedBonus);
         if (Math.abs(dx) > 0.05) {
           hero.position.x += Math.sign(dx) * Math.min(Math.abs(dx), speed * dt);
@@ -632,13 +655,8 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
         const by = Math.round(hero.position.y);
         if (!bombs.some(b => b.position.x === bx && b.position.y === by)) {
           // Calculer les bonus de clan skills actifs
-          const activeSkills = getActiveClanSkills(heroes);
-          const rangBonus = activeSkills
-            .filter(s => s.effect.type === 'bomb_range')
-            .reduce((acc, s) => acc + s.effect.value, 0);
-          const timerBonus = activeSkills
-            .filter(s => s.effect.type === 'bomb_timer')
-            .reduce((acc, s) => acc + s.effect.value, 0);
+          const rangBonus = getClanBonus('bomb_range', heroes);
+          const timerBonus = getClanBonus('bomb_timer', heroes);
           bombs.push({
             id: genId(),
             heroId: hero.id,
@@ -695,12 +713,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       // In story mode with enemies alive, re-target faster (0.15s vs 0.3s)
       const hasAliveEnemies = state.enemies?.some(e => e.hp > 0) || (state.isStoryMode && state.boss && (state.boss as Boss).hp > 0);
       const retargetDelay = (state.isStoryMode && hasAliveEnemies) ? 0.15 : 0.3;
-      const storyTargets = state.isStoryMode && state.boss && (state.boss as Boss).hp > 0
-        ? [
-            ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
-            { ...(state.boss as Boss), isBoss: true },
-          ]
-        : state.enemies;
+      const storyTargets = buildStoryTargets(state);
 
       if (hero.stuckTimer >= retargetDelay) {
         const target = findNearestTarget(map, hero, bombs, map.chests, storyTargets, state.isStoryMode);
@@ -727,12 +740,7 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
       // Every 0.8s, re-evaluate if there's a closer enemy
       if (hero.stuckTimer >= 0.8) {
         hero.stuckTimer = 0;
-        const retargets = state.boss && (state.boss as Boss).hp > 0
-          ? [
-              ...(state.enemies || []).map(e => ({ ...e, isBoss: false })),
-              { ...(state.boss as Boss), isBoss: true },
-            ]
-          : state.enemies;
+        const retargets = buildStoryTargets(state);
         const betterTarget = findNearestTarget(map, hero, bombs, map.chests, retargets, true);
         if (betterTarget && hero.targetPosition) {
           const currentDist = Math.abs(hero.targetPosition.x - hx) + Math.abs(hero.targetPosition.y - hy);


### PR DESCRIPTION
## Milestone M4 — Performance

Ferme les issues : #300 #301 #302 #303

## Changements

### #302 — Logique de bonus clan dupliquée 3x (`engine.ts`)
- Nouveau helper local `getClanBonus(effectType, heroes)` qui encapsule `getActiveClanSkills().filter().reduce()`
- Remplacement des 3 occurrences (`coinBonus`, `speedBonus`, `rangBonus`/`timerBonus`)
- Import de `ClanSkillEffect` ajouté pour le typage

### #300 — buildStoryTargets extrait (`engine.ts`)
- Nouveau helper local `buildStoryTargets(state)` qui centralise la construction de la liste de cibles Story (ennemis normaux + boss avec `isBoss: true`)
- Construction dupliquée 2x dans `tickGame` → 1 seul appel
- `findNearestTarget` elle-même non modifiée (risque de régression, logique A* complexe)

### #301 — Double filtrage dans HeroPickerModal (`HeroPickerModal.tsx`)
- Remplacement de 2 appels `heroes.filter(getEligibility)` par un `useMemo` avec boucle unique
- `getEligibility` appelée 1x par héros au lieu de 2x
- Memoïsé sur `[heroes, requiredRarity, alreadySelectedIds]`

### #303 — Itérations achievements memoïsées (`Achievements.tsx`)
- `getUnlockedAchievements`, `getInProgressAchievements`, `getLockedAchievements` et `claimableIds` encapsulés dans un `useMemo([achievements])`
- Évite les recalculs O(n) sur ACHIEVEMENTS à chaque re-render

## Test plan
- [ ] Build sans erreur TypeScript ✅ (`npm run build`)
- [ ] Lancer une partie Story Mode — vérifier que les ennemis/boss sont bien ciblés
- [ ] Vérifier que les bonus de pièces/vitesse/range des clans s'appliquent correctement
- [ ] Ouvrir HeroPickerModal (fusion) — vérifier le tri eligible/ineligible
- [ ] Ouvrir l'écran Achievements — vérifier les onglets unlocked/in-progress/locked

🤖 Generated with [Claude Code](https://claude.com/claude-code)