### PR TITLE
fix: bouton mute manquant + colonne vide desktop en battle

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -41,7 +41,7 @@ import MainNav from '@/components/MainNav';
 import TeamPresets, { TeamPreset } from '@/components/TeamPresets';
 import PixelLoader from '@/components/PixelLoader';
 import EmptyState from '@/components/EmptyState';
-import { Users, Sparkles, Swords, Map as MapIcon, Trophy, Coins, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Lock as LockIcon, Hammer, ArrowDown, Gem, Filter, ChevronDown, Zap } from 'lucide-react';
+import { Users, Sparkles, Swords, Map as MapIcon, Trophy, Coins, Play, Pause, DoorOpen, Check, Scroll, FastForward, BookOpen, Shield, Skull, Lock as LockIcon, Hammer, ArrowDown, Gem, Filter, ChevronDown, Zap, Volume2, VolumeX } from 'lucide-react';
 import PityTracker from '@/components/PityTracker';
 import VictoryOverlay from '@/components/VictoryOverlay';
 import DefeatOverlay from '@/components/DefeatOverlay';
@@ -2064,7 +2064,7 @@ const Index = () => {
         </div>
 
         {/* PAGE 2 — Combat */}
-        <div className="w-1/5 h-full overflow-y-auto pb-nav md:pl-16">
+        <div className={`w-1/5 h-full overflow-y-auto pb-nav ${isInBattle ? '' : 'md:pl-16'}`}>
           <div className="p-4 max-w-6xl mx-auto">
             {/* Tabs Chasse au Trésor / Mode Histoire */}
             {!isInBattle && (
@@ -2344,7 +2344,18 @@ const Index = () => {
                         : <><Pause size={14} className="shrink-0" /><span className="leading-none">Pause</span></>}
                     </button>
 
-                    {/* Contrôle 3 — Quitter / Récupérer */}
+                    {/* Contrôle 3 — Son */}
+                    <button
+                      onClick={toggleMute}
+                      className="pixel-btn pixel-btn-secondary font-pixel text-[9px] flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 min-h-0"
+                      title={muted ? 'Activer le son' : 'Couper le son'}
+                    >
+                      {muted
+                        ? <><VolumeX size={14} className="shrink-0" /><span className="leading-none">Son</span></>
+                        : <><Volume2 size={14} className="shrink-0" /><span className="leading-none">Son</span></>}
+                    </button>
+
+                    {/* Contrôle 4 — Quitter / Récupérer */}
                     <button
                       onClick={gameState.isStoryMode ? endStoryBattle : endTreasureHunt}
                       className={`pixel-btn font-pixel text-[9px] flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 min-h-0 ${


### PR DESCRIPTION
## Problèmes corrigés

- **Bouton mute disparu** : la fonction `toggleMute` existait (ligne 223) mais le bouton JSX n'était jamais rendu. Ajout du bouton Son (Volume2/VolumeX) entre Pause et Quitter dans le HUD.
- **Colonne vide sur desktop en mode battle** : quand `isInBattle = true`, le `MainNav` est caché mais la page Combat gardait `md:pl-16`, laissant 64px vide à gauche. Le padding est maintenant conditionnel.

## Changements

- `src/pages/Index.tsx` :
  - Import `Volume2, VolumeX` depuis lucide-react
  - Ajout du bouton mute dans le HUD (Contrôle 3 — Son)
  - Page Combat : `md:pl-16` retiré quand `isInBattle`

## Test plan
- [ ] Lancer une chasse au trésor → vérifier que le bouton Son s'affiche dans le HUD
- [ ] Cliquer sur Son → le son se coupe, icône change sur VolumeX
- [ ] Desktop : démarrer une chasse → vérifier qu'il n'y a plus de colonne vide à gauche

🤖 Generated with [Claude Code](https://claude.com/claude-code)