### PR TITLE
fix: tutoriel se relance à chaque connexion — conserver tutorialStep undefined

### DIFF
--- a/src/hooks/useCloudSave.ts
+++ b/src/hooks/useCloudSave.ts
@@ -136,6 +136,12 @@ export function useCloudSave(userId: string | undefined, canWriteCloud: boolean)
       ...getDefaultPlayerData(),  // valeurs par défaut pour tout champ manquant
       ...(statsOnly as PlayerData),
       heroes,
+      // tutorialStep: undefined = tutoriel terminé. Comme JSON.stringify omet les valeurs undefined,
+      // un joueur ayant terminé le tutoriel n'aura pas cette clé dans statsOnly.
+      // Sans cette ligne, getDefaultPlayerData() imposerait 0 et relancerait le tutoriel.
+      tutorialStep: 'tutorialStep' in (statsOnly ?? {})
+        ? (statsOnly as PlayerData).tutorialStep
+        : undefined,
     };
 
     console.log('CLOUD_LOAD_ROWS', {


### PR DESCRIPTION
## Bug

Le tutoriel se relançait à chaque connexion pour les joueurs ayant déjà terminé le jeu.

## Cause

Dans `useCloudSave.ts`, la construction de `playerData` au chargement cloud :

```ts
const playerData = {
  ...getDefaultPlayerData(),  // tutorialStep: 0 ← imposé ici
  ...(statsOnly as PlayerData),  // statsOnly n'a PAS la clé si undefined
};
```

`JSON.stringify` omet les valeurs `undefined`. Un joueur ayant terminé le tutoriel a `tutorialStep: undefined` → la clé est absente de `statsOnly` → `getDefaultPlayerData()` impose `0` → le tutoriel repart.

## Fix

```ts
tutorialStep: 'tutorialStep' in (statsOnly ?? {})
  ? (statsOnly as PlayerData).tutorialStep
  : undefined,
```

- Joueur existant (tutoriel terminé) : clé absente → `undefined` ✅
- Joueur en cours de tutoriel : clé présente avec valeur 0-5 → conservée ✅
- Nouvel utilisateur sans save : branche `null` → `getDefaultPlayerData()` → `0` ✅

## Validation
- ✅ Build sans erreur
- ✅ 169/169 tests passent

🤖 Generated with [Claude Code](https://claude.com/claude-code)