### PR TITLE
fix: débloquer les étapes histoire par progression séquentielle (#322)

### DIFF
--- a/src/components/StoryMode.tsx
+++ b/src/components/StoryMode.tsx
@@ -132,7 +132,7 @@ const StoryMode: React.FC<StoryModeProps> = ({
             {region.stages.map((stage, i) => {
               const isCompleted = storyProgress.completedStages.includes(stage.id);
               const prevCompleted = i === 0 || storyProgress.completedStages.includes(region.stages[i - 1].id);
-              const isLocked = !prevCompleted || player.accountLevel < stage.unlockLevel;
+              const isLocked = !prevCompleted;
 
               return (
                 <button

--- a/src/hooks/useCloudSync.ts
+++ b/src/hooks/useCloudSync.ts
@@ -123,7 +123,7 @@ export function useCloudSync(
       console.error('CLOUD_LOAD_UNEXPECTED_ERROR', { code: error.code || 'UNKNOWN', message: error.message });
       setCloudValidated(false);
       cloudLoadedRef.current = true;
-      toast({ title: 'Cloud indisponible', description: 'Impossible de charger la sauvegarde. Réessaie.', duration: 4000 });
+      toast('Cloud indisponible', { description: 'Impossible de charger la sauvegarde. Réessaie.', duration: 4000 });
     }).finally(() => {
       if (!cancelled) setIsCloudLoading(false);
     });


### PR DESCRIPTION
## Problème

Les étapes du Mode Histoire restaient verrouillées après victoire.

**Cause racine** : chaque étape avait un `unlockLevel` croissant (ex: Forteresse Orc — étape 1: level 22, étape 2: level 24, étape 3: level 26…). La condition de verrouillage était :
```ts
const isLocked = !prevCompleted || player.accountLevel < stage.unlockLevel;
```
Résultat : un joueur level 22 qui termine les étapes 1 et 2 ne peut pas accéder à l'étape 3 car il n'est pas encore level 26.

## Fix

La progression dans une région doit être **séquentielle** : compléter l'étape N débloque l'étape N+1, point. Le level minimum est déjà géré par `isRegionLocked` au niveau de la région.

```ts
// Avant
const isLocked = !prevCompleted || player.accountLevel < stage.unlockLevel;

// Après
const isLocked = !prevCompleted;
```

## Bonus

Corrige un toast au format Radix résiduel dans `useCloudSync.ts` (migré vers Sonner, closes #265 résidu).

## Test

1. Créer un compte niveau 22
2. Aller dans Mode Histoire → Forteresse Orc
3. Compléter l'étape 1 ("Remparts")
4. Vérifier que l'étape 2 ("Caserne") est bien déverrouillée
5. Compléter l'étape 2
6. Vérifier que l'étape 3 ("Armurerie") est déverrouillée ✅

Closes #322

🤖 Generated with [Claude Code](https://claude.com/claude-code)