### PR TITLE
feat: compétences débloquées progressivement tous les 20 niveaux + héritage niveau fusion

### DIFF
--- a/src/components/HeroCard.tsx
+++ b/src/components/HeroCard.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Hero, RARITY_CONFIG, MAX_LEVEL_BY_RARITY } from '@/game/types';
-import { getXpProgress } from '@/game/upgradeSystem';
+import { getXpProgress, getUnlockedSkills } from '@/game/upgradeSystem';
 import { Swords, Zap, Target, Bomb, Battery, Clover, Shield, Star, Moon, Check, Sparkles } from 'lucide-react';
 import HeroAvatar from '@/components/HeroAvatar';
 
@@ -167,9 +167,9 @@ const HeroCard: React.FC<HeroCardProps> = ({ hero, compact, onClick, selected })
           ))}
         </div>
 
-        {hero.skills.length > 0 && (
+        {getUnlockedSkills(hero).length > 0 && (
           <div className="mt-2 space-y-0.5">
-            {hero.skills.map((skill, i) => (
+            {getUnlockedSkills(hero).map((skill, i) => (
               <p key={i} className="text-[8px] text-accent truncate flex items-center gap-1" title={skill.description}>
                 <Zap size={8} /> {skill.name}
               </p>

--- a/src/components/HeroDetailContent.tsx
+++ b/src/components/HeroDetailContent.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import HeroAvatar from '@/components/HeroAvatar';
 import { Hero, RARITY_CONFIG } from '@/game/types';
-import { getStatsAtLevel, getAscensionCost, MAX_STARS, countDuplicates, getXpProgress, getMaxLevel } from '@/game/upgradeSystem';
+import { getStatsAtLevel, getAscensionCost, MAX_STARS, countDuplicates, getXpProgress, getMaxLevel, getUnlockedSkills } from '@/game/upgradeSystem';
 import { Progress } from '@/components/ui/progress';
 import { Swords, Zap, Target, Bomb, Battery, Clover, Shield, Star, ArrowUp, Coins, TrendingUp, Lock, Sparkles, Users, User, Calendar, Trophy, Gem } from 'lucide-react';
 
@@ -205,14 +205,22 @@ const HeroDetailContent: React.FC<HeroDetailContentProps> = ({
           <p className="font-pixel text-[9px] text-muted-foreground flex items-center gap-1">
             <Zap size={10} /> COMPÉTENCES
           </p>
-          {hero.skills.map((skill, i) => (
-            <div key={i} className={skillCardClass}>
-              <p className="text-foreground font-medium flex items-center gap-1">
-                <Zap size={9} className="text-accent" /> {skill.name}
-              </p>
-              <p className="text-muted-foreground mt-0.5">{skill.description}</p>
-            </div>
-          ))}
+          {hero.skills.map((skill, i) => {
+            const unlockLevel = (i + 1) * 20;
+            const isUnlocked = hero.level >= unlockLevel;
+            return (
+              <div key={i} className={`${skillCardClass} ${!isUnlocked ? 'opacity-50' : ''}`}>
+                <p className={`font-medium flex items-center gap-1 ${isUnlocked ? 'text-foreground' : 'text-muted-foreground'}`}>
+                  {isUnlocked ? <Zap size={9} className="text-accent" /> : <Lock size={9} />} {skill.name}
+                </p>
+                {isUnlocked ? (
+                  <p className="text-muted-foreground mt-0.5">{skill.description}</p>
+                ) : (
+                  <p className="text-muted-foreground mt-0.5">Débloqué niveau {unlockLevel}</p>
+                )}
+              </div>
+            );
+          })}
         </div>
       )}
 

--- a/src/game/upgradeSystem.ts
+++ b/src/game/upgradeSystem.ts
@@ -400,6 +400,14 @@ export function countDuplicates(heroes: Hero[], heroId: string, rarity: Rarity):
   return heroes.filter(h => h.id !== heroId && h.rarity === rarity).length;
 }
 
+/**
+ * Retourne uniquement les compétences débloquées du héros.
+ * Règle : skill[i] (0-indexed) se débloque au niveau (i+1) * 20.
+ */
+export function getUnlockedSkills(hero: Hero): Skill[] {
+  return hero.skills.filter((_, i) => hero.level >= (i + 1) * 20);
+}
+
 // Coût en nombre de doublons par level de skill (index = level actuel)
 const SKILL_UPGRADE_COST = [0, 1, 2, 3, 5]; // Pour passer du level 1→2, 2→3, 3→4, 4→5
 

--- a/src/hooks/useFusionLogic.ts
+++ b/src/hooks/useFusionLogic.ts
@@ -102,6 +102,7 @@ export function useFusionLogic({
     const toRemove = new Set(available.slice(0, count).map(h => h.id));
     const removedIds = Array.from(toRemove);
     const newHero = generateHero(to);
+    newHero.level = RARITY_CONFIG[from].maxLevel;
     const mergedHeroes = [...player.heroes.filter(h => !toRemove.has(h.id)), newHero];
 
     setPlayer(prev => ({
@@ -130,6 +131,7 @@ export function useFusionLogic({
     const toRemove = new Set(filledSlots.map(h => h.id));
     const removedIds = Array.from(toRemove);
     const newHero = generateHero(recipe.to);
+    newHero.level = RARITY_CONFIG[recipe.from].maxLevel;
     const mergedHeroes = [...player.heroes.filter(h => !toRemove.has(h.id)), newHero];
 
     setPlayer(prev => ({
@@ -188,6 +190,7 @@ export function useFusionLogic({
         if (available.length >= recipe.count) {
           const toRemove = new Set(available.slice(0, recipe.count).map(h => h.id));
           const newHero = generateHero(recipe.to);
+          newHero.level = RARITY_CONFIG[recipe.from].maxLevel;
           currentHeroes = [...currentHeroes.filter(h => !toRemove.has(h.id)), newHero];
           mergeCount++;
           madeProgress = true;

--- a/supabase/migrations/20260320_bump_heroes_to_max_level.sql
+++ b/supabase/migrations/20260320_bump_heroes_to_max_level.sql
@@ -1,0 +1,9 @@
+-- Migration: bumper tous les héros existants à leur niveau maximum selon leur rareté
+-- Cela rend les compétences progressives effectives pour les héros déjà invoqués
+
+UPDATE player_heroes SET level = 20  WHERE rarity = 'common'       AND level < 20;
+UPDATE player_heroes SET level = 40  WHERE rarity = 'rare'         AND level < 40;
+UPDATE player_heroes SET level = 60  WHERE rarity = 'super-rare'   AND level < 60;
+UPDATE player_heroes SET level = 80  WHERE rarity = 'epic'         AND level < 80;
+UPDATE player_heroes SET level = 100 WHERE rarity = 'legend'       AND level < 100;
+UPDATE player_heroes SET level = 120 WHERE rarity = 'super-legend' AND level < 120;


### PR DESCRIPTION
## Résumé

Les compétences des héros se débloquent désormais progressivement à chaque palier de 20 niveaux, au lieu d'être toutes disponibles dès l'invocation.

## Règle de déblocage

```
skill[i] débloqué si hero.level >= (i + 1) * 20
```

| Rareté | Max Lv | Skills |
|--------|--------|--------|
| Common | 20 | 0 skill |
| Rare | 40 | Lv20 |
| Super-Rare | 60 | Lv20, Lv40 |
| Epic | 80 | Lv20, Lv40, Lv60 |
| Legend | 100 | Lv20, 40, 60, 80 |
| Super-Legend | 120 | Lv20, 40, 60, 80, 100 |

## Changements

- **`upgradeSystem.ts`** — nouvelle fonction `getUnlockedSkills(hero)` exportée
- **`HeroDetailContent.tsx`** — skills verrouillées affichées avec cadenas + "Débloqué niveau X"
- **`HeroCard.tsx`** — seules les skills débloquées apparaissent en vue compacte
- **`useFusionLogic.ts`** — le héros résultant hérite du niveau max des ingrédients (`RARITY_CONFIG[from].maxLevel`), ses skills sont donc déjà partiellement débloquées
- **`supabase/migrations/20260320_bump_heroes_to_max_level.sql`** — migration pour bumper les héros existants en bêta à leur niveau max

## Test

1. Invoquer un Rare → aucune skill visible (lv1)
2. Monter ce Rare au niveau 20 → skill 1 débloquée ✅
3. Fusionner 2 Commons lv20 → le Rare résultant est lv20, skill 1 débloquée ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)