### PR TITLE
fix: bouton mute déplacé dans la SlimHeader — HUD combat équilibré

### DIFF
--- a/src/components/SlimHeader.tsx
+++ b/src/components/SlimHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Coins, Gem, Crown, User } from 'lucide-react';
+import { Coins, Gem, Crown, User, Volume2, VolumeX } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import PixelIcon from '@/components/PixelIcon';
 
@@ -11,6 +11,8 @@ interface SlimHeaderProps {
   xpToNextLevel?: number;
   title?: string;
   onProfileClick?: () => void;
+  muted?: boolean;
+  onToggleMute?: () => void;
 }
 
 export function SlimHeader({
@@ -21,6 +23,8 @@ export function SlimHeader({
   xpToNextLevel = 100,
   title,
   onProfileClick,
+  muted,
+  onToggleMute,
 }: SlimHeaderProps) {
   const xpPercent = xpToNextLevel > 0
     ? Math.min(100, Math.round((accountXp / xpToNextLevel) * 100))
@@ -59,6 +63,15 @@ export function SlimHeader({
             <Gem size={13} style={{ color: 'hsl(var(--game-rarity-rare))' }} />
             <span>{universalShards.toLocaleString('fr-FR')}</span>
           </div>
+          {onToggleMute && (
+            <button
+              onClick={onToggleMute}
+              className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              title={muted ? 'Activer le son' : 'Couper le son'}
+            >
+              {muted ? <VolumeX size={14} /> : <Volume2 size={14} />}
+            </button>
+          )}
           {onProfileClick && (
             <button
               onClick={onProfileClick}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1236,6 +1236,8 @@ const Index = () => {
         xpToNextLevel={getXpInCurrentLevel(player.xp).xpNeeded}
         title={PAGE_TITLES[page]}
         onProfileClick={user ? () => navigate("/profile") : undefined}
+        muted={muted}
+        onToggleMute={toggleMute}
       />
 
       {/* Container swipeable 5 pages */}
@@ -2002,18 +2004,7 @@ const Index = () => {
                         : <><Pause size={14} className="shrink-0" /><span className="leading-none">Pause</span></>}
                     </button>
 
-                    {/* Contrôle 3 — Son */}
-                    <button
-                      onClick={toggleMute}
-                      className="pixel-btn pixel-btn-secondary font-pixel text-[9px] flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 min-h-0"
-                      title={muted ? 'Activer le son' : 'Couper le son'}
-                    >
-                      {muted
-                        ? <><VolumeX size={14} className="shrink-0" /><span className="leading-none">Son</span></>
-                        : <><Volume2 size={14} className="shrink-0" /><span className="leading-none">Son</span></>}
-                    </button>
-
-                    {/* Contrôle 4 — Quitter / Récupérer */}
+                    {/* Contrôle 3 — Quitter / Récupérer */}
                     <button
                       onClick={gameState.isStoryMode ? endStoryBattle : endTreasureHunt}
                       className={`pixel-btn font-pixel text-[9px] flex flex-col items-center justify-center gap-0.5 px-2 py-1.5 min-h-0 ${


### PR DESCRIPTION
## Résumé

Le bouton mute était dans le HUD de combat, créant un déséquilibre (3 stats + 4 contrôles). Il est désormais dans la `SlimHeader`, visible en permanence dans toute l'app.

## Changements

- **`SlimHeader.tsx`** — ajout props `muted?` + `onToggleMute?`, bouton Volume2/VolumeX à droite du header
- **`Index.tsx`** — passage des props à SlimHeader, suppression du bloc "Contrôle 3 — Son" du HUD

## Résultat

- HUD de combat : 3 stats + 3 contrôles (vitesse, pause, quitter) → grille équilibrée ✅
- Bouton mute : accessible depuis n'importe quel écran de jeu via la top bar ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)