### PR TITLE
feat: interface équipe refactorisée — slots cliquables, picker filtré, synergies clan

### DIFF
--- a/src/components/FusionHeroPickerModal.tsx
+++ b/src/components/FusionHeroPickerModal.tsx
@@ -1,0 +1,165 @@
+import React, { useMemo } from 'react';
+import {
+  Dialog,
+  DialogContent,
+} from '@/components/ui/dialog';
+import { Hero, RARITY_CONFIG } from '@/game/types';
+import PixelIcon from '@/components/PixelIcon';
+import { AlertCircle, Check, Users } from 'lucide-react';
+import { motion, AnimatePresence } from 'framer-motion';
+import EmptyState from '@/components/EmptyState';
+import { pixelPop } from '@/lib/animations';
+
+interface FusionHeroPickerModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelect: (hero: Hero) => void;
+  heroes: Hero[];
+  requiredRarity: string;
+  requiredCount: number;
+  alreadySelectedIds: string[];
+}
+
+interface HeroEligibility {
+  hero: Hero;
+  isEligible: boolean;
+  reason: string;
+}
+
+const FusionHeroPickerModal: React.FC<FusionHeroPickerModalProps> = ({
+  isOpen,
+  onClose,
+  onSelect,
+  heroes,
+  requiredRarity,
+  requiredCount,
+  alreadySelectedIds,
+}) => {
+  const requiredRarityConfig = RARITY_CONFIG[requiredRarity as keyof typeof RARITY_CONFIG];
+  const maxLevel = requiredRarityConfig?.maxLevel ?? 20;
+
+  const getEligibility = (hero: Hero): HeroEligibility => {
+    if (alreadySelectedIds.includes(hero.id)) {
+      return { hero, isEligible: false, reason: 'Déjà assigné' };
+    }
+    if (hero.rarity !== requiredRarity) {
+      return { hero, isEligible: false, reason: `Rareté ${RARITY_CONFIG[hero.rarity as keyof typeof RARITY_CONFIG]?.label ?? hero.rarity} requise` };
+    }
+    if (hero.level < maxLevel) {
+      return { hero, isEligible: false, reason: `Niveau ${maxLevel} requis (${hero.level}/${maxLevel})` };
+    }
+    return { hero, isEligible: true, reason: '' };
+  };
+
+  const { eligibleHeroes, ineligibleHeroes, sortedHeroes } = useMemo(() => {
+    const eligible: Hero[] = [], ineligible: Hero[] = [];
+    for (const h of heroes) {
+      (getEligibility(h).isEligible ? eligible : ineligible).push(h);
+    }
+    return { eligibleHeroes: eligible, ineligibleHeroes: ineligible, sortedHeroes: [...eligible, ...ineligible] };
+  }, [heroes, requiredRarity, alreadySelectedIds]);
+
+  return (
+    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
+        <div className="flex items-center justify-between pb-4 border-b">
+          <div>
+            <h2 className="font-pixel text-[10px] text-foreground flex items-center gap-2 uppercase">
+              Choisir un héros
+            </h2>
+            <p className="font-pixel text-[8px] text-muted-foreground mt-1">
+              {requiredCount}× {requiredRarityConfig?.label ?? requiredRarity} niv. {maxLevel} requis(s)
+            </p>
+          </div>
+        </div>
+
+        <div className="flex-1 overflow-y-auto py-4">
+          {sortedHeroes.length === 0 ? (
+            <EmptyState
+              icon={Users}
+              title="Aucun héros disponible"
+              description={`Besoin d'héros ${requiredRarityConfig?.label ?? requiredRarity} niveau ${maxLevel}.`}
+              className="py-4"
+            />
+          ) : (
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+              <AnimatePresence>
+                {sortedHeroes.map((hero) => {
+                  const eligibility = getEligibility(hero);
+                  return (
+                    <motion.button
+                      key={hero.id}
+                      variants={pixelPop}
+                      initial="hidden"
+                      animate="visible"
+                      exit="exit"
+                      onClick={() => eligibility.isEligible && onSelect(hero)}
+                      disabled={!eligibility.isEligible}
+                      className={`pixel-border p-3 flex flex-col items-center gap-2 transition-all relative ${
+                        eligibility.isEligible
+                          ? 'bg-card hover:bg-card hover:scale-105 cursor-pointer ring-2 ring-game-energy-green/30'
+                          : 'bg-muted/30 cursor-not-allowed opacity-60 grayscale'
+                      }`}
+                    >
+                      {eligibility.isEligible && (
+                        <div className="absolute top-1 right-1 w-4 h-4 rounded-full bg-game-energy-green flex items-center justify-center">
+                          <Check size={10} className="text-background" />
+                        </div>
+                      )}
+
+                      <div
+                        className="w-12 h-12 rounded-lg flex items-center justify-center"
+                        style={{
+                          boxShadow: eligibility.isEligible
+                            ? `0 0 12px hsl(var(--game-rarity-${hero.rarity}) / 0.4)`
+                            : 'none'
+                        }}
+                      >
+                        <PixelIcon icon={hero.icon} size={28} rarity={hero.rarity} />
+                      </div>
+
+                      <div className="text-center">
+                        <p className="font-pixel text-[8px] text-foreground truncate w-full">{hero.name}</p>
+                        <div className="flex items-center justify-center gap-1 mt-0.5">
+                          <span
+                            className="font-pixel text-[7px]"
+                            style={{
+                              color: hero.level >= maxLevel
+                                ? 'hsl(var(--game-energy-green))'
+                                : `hsl(var(--game-rarity-${hero.rarity}))`
+                            }}
+                          >
+                            {hero.level}/{maxLevel}
+                          </span>
+                          {hero.level >= maxLevel && (
+                            <span className="text-[8px] text-game-energy-green">★</span>
+                          )}
+                        </div>
+                      </div>
+
+                      {!eligibility.isEligible && (
+                        <p className="text-[8px] text-destructive flex items-center gap-0.5 mt-1">
+                          <AlertCircle size={8} /> {eligibility.reason}
+                        </p>
+                      )}
+                    </motion.button>
+                  );
+                })}
+              </AnimatePresence>
+            </div>
+          )}
+        </div>
+
+        <div className="pt-4 border-t flex items-center justify-between">
+          <div className="font-pixel text-[8px] text-muted-foreground">
+            <span className="text-game-energy-green">{eligibleHeroes.length}</span> éligible(s)
+            {' • '}
+            <span>{ineligibleHeroes.length}</span> non éligible(s)
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default FusionHeroPickerModal;

--- a/src/components/HeroPickerModal.tsx
+++ b/src/components/HeroPickerModal.tsx
@@ -1,161 +1,94 @@
-import React, { useMemo } from 'react';
-import {
-  Dialog,
-  DialogContent,
-} from '@/components/ui/dialog';
-import { Hero, RARITY_CONFIG } from '@/game/types';
-import PixelIcon from '@/components/PixelIcon';
-import { X, AlertCircle, Check, Users } from 'lucide-react';
-import { motion, AnimatePresence } from 'framer-motion';
-import EmptyState from '@/components/EmptyState';
-import { pixelPop } from '@/lib/animations';
+import React, { useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Hero, Rarity, RARITY_CONFIG, HERO_FAMILIES } from '@/game/types';
+import HeroCard from '@/components/HeroCard';
 
 interface HeroPickerModalProps {
-  isOpen: boolean;
-  onClose: () => void;
-  onSelect: (hero: Hero) => void;
+  open: boolean;
   heroes: Hero[];
-  requiredRarity: string;
-  requiredCount: number;
-  alreadySelectedIds: string[];
-}
-
-interface HeroEligibility {
-  hero: Hero;
-  isEligible: boolean;
-  reason: string;
+  selectedIds: Set<string>;
+  onSelect: (hero: Hero) => void;
+  onClose: () => void;
 }
 
 const HeroPickerModal: React.FC<HeroPickerModalProps> = ({
-  isOpen,
-  onClose,
-  onSelect,
+  open,
   heroes,
-  requiredRarity,
-  requiredCount,
-  alreadySelectedIds,
+  selectedIds,
+  onSelect,
+  onClose,
 }) => {
-  const requiredRarityConfig = RARITY_CONFIG[requiredRarity as keyof typeof RARITY_CONFIG];
-  const maxLevel = requiredRarityConfig?.maxLevel ?? 20;
+  const [rarityFilter, setRarityFilter] = useState<'all' | Rarity>('all');
+  const [clanFilter, setClanFilter] = useState<'all' | string>('all');
 
-  const getEligibility = (hero: Hero): HeroEligibility => {
-    if (alreadySelectedIds.includes(hero.id)) {
-      return { hero, isEligible: false, reason: 'Déjà assigné' };
-    }
-    if (hero.rarity !== requiredRarity) {
-      return { hero, isEligible: false, reason: `Rareté ${RARITY_CONFIG[hero.rarity as keyof typeof RARITY_CONFIG]?.label ?? hero.rarity} requise` };
-    }
-    if (hero.level < maxLevel) {
-      return { hero, isEligible: false, reason: `Niveau ${maxLevel} requis (${hero.level}/${maxLevel})` };
-    }
-    return { hero, isEligible: true, reason: '' };
-  };
+  const filtered = useMemo(() => {
+    return [...heroes]
+      .filter(h => rarityFilter === 'all' || h.rarity === rarityFilter)
+      .filter(h => clanFilter === 'all' || h.family === clanFilter)
+      .sort((a, b) => b.level - a.level);
+  }, [heroes, rarityFilter, clanFilter]);
 
-  const { eligibleHeroes, ineligibleHeroes, sortedHeroes } = useMemo(() => {
-    const eligible: Hero[] = [], ineligible: Hero[] = [];
-    for (const h of heroes) {
-      (getEligibility(h).isEligible ? eligible : ineligible).push(h);
-    }
-    return { eligibleHeroes: eligible, ineligibleHeroes: ineligible, sortedHeroes: [...eligible, ...ineligible] };
-  }, [heroes, requiredRarity, alreadySelectedIds]);
+  const isFull = selectedIds.size >= 6;
 
   return (
-    <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-w-2xl max-h-[80vh] overflow-hidden flex flex-col">
-        <div className="flex items-center justify-between pb-4 border-b">
-          <div>
-            <h2 className="font-pixel text-[10px] text-foreground flex items-center gap-2 uppercase">
-              Choisir un héros
-            </h2>
-            <p className="font-pixel text-[8px] text-muted-foreground mt-1">
-              {requiredCount}× {requiredRarityConfig?.label ?? requiredRarity} niv. {maxLevel} requis(s)
-            </p>
-          </div>
+    <Dialog open={open} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-2xl max-h-[85vh] overflow-hidden flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="font-pixel text-[10px] uppercase">Choisir un héros</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-wrap gap-2 pb-3 border-b border-border">
+          <select
+            value={rarityFilter}
+            onChange={e => setRarityFilter(e.target.value as 'all' | Rarity)}
+            className="font-pixel text-[8px] bg-muted border border-border rounded px-2 py-1 text-foreground outline-none"
+          >
+            <option value="all">Toutes raretés</option>
+            {(Object.keys(RARITY_CONFIG) as Rarity[]).map(r => (
+              <option key={r} value={r}>{RARITY_CONFIG[r].label}</option>
+            ))}
+          </select>
+
+          <select
+            value={clanFilter}
+            onChange={e => setClanFilter(e.target.value)}
+            className="font-pixel text-[8px] bg-muted border border-border rounded px-2 py-1 text-foreground outline-none"
+          >
+            <option value="all">Tous les clans</option>
+            {HERO_FAMILIES.map(f => (
+              <option key={f.id} value={f.id}>{f.name}</option>
+            ))}
+          </select>
+
+          <span className="font-pixel text-[8px] text-muted-foreground self-center ml-auto">
+            {filtered.length} héros
+          </span>
         </div>
 
-        <div className="flex-1 overflow-y-auto py-4">
-          {sortedHeroes.length === 0 ? (
-            <EmptyState
-              icon={Users}
-              title="Aucun héros disponible"
-              description={`Besoin d'héros ${requiredRarityConfig?.label ?? requiredRarity} niveau ${maxLevel}.`}
-              className="py-4"
-            />
+        <div className="flex-1 overflow-y-auto py-3">
+          {filtered.length === 0 ? (
+            <p className="font-pixel text-[8px] text-muted-foreground text-center py-8">Aucun héros trouvé</p>
           ) : (
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
-              <AnimatePresence>
-                {sortedHeroes.map((hero) => {
-                  const eligibility = getEligibility(hero);
-                  return (
-                    <motion.button
-                      key={hero.id}
-                      variants={pixelPop}
-                      initial="hidden"
-                      animate="visible"
-                      exit="exit"
-                      onClick={() => eligibility.isEligible && onSelect(hero)}
-                      disabled={!eligibility.isEligible}
-                      className={`pixel-border p-3 flex flex-col items-center gap-2 transition-all relative ${
-                        eligibility.isEligible
-                          ? 'bg-card hover:bg-card hover:scale-105 cursor-pointer ring-2 ring-game-energy-green/30'
-                          : 'bg-muted/30 cursor-not-allowed opacity-60 grayscale'
-                      }`}
-                    >
-                      {eligibility.isEligible && (
-                        <div className="absolute top-1 right-1 w-4 h-4 rounded-full bg-game-energy-green flex items-center justify-center">
-                          <Check size={10} className="text-background" />
-                        </div>
-                      )}
-
-                      <div 
-                        className="w-12 h-12 rounded-lg flex items-center justify-center"
-                        style={{ 
-                          boxShadow: eligibility.isEligible 
-                            ? `0 0 12px hsl(var(--game-rarity-${hero.rarity}) / 0.4)` 
-                            : 'none'
-                        }}
-                      >
-                        <PixelIcon icon={hero.icon} size={28} rarity={hero.rarity} />
-                      </div>
-
-                      <div className="text-center">
-                        <p className="font-pixel text-[8px] text-foreground truncate w-full">{hero.name}</p>
-                        <div className="flex items-center justify-center gap-1 mt-0.5">
-                          <span 
-                            className="font-pixel text-[7px]" 
-                            style={{ 
-                              color: hero.level >= maxLevel 
-                                ? 'hsl(var(--game-energy-green))' 
-                                : `hsl(var(--game-rarity-${hero.rarity}))` 
-                            }}
-                          >
-                            {hero.level}/{maxLevel}
-                          </span>
-                          {hero.level >= maxLevel && (
-                            <span className="text-[8px] text-game-energy-green">★</span>
-                          )}
-                        </div>
-                      </div>
-
-                      {!eligibility.isEligible && (
-                        <p className="text-[8px] text-destructive flex items-center gap-0.5 mt-1">
-                          <AlertCircle size={8} /> {eligibility.reason}
-                        </p>
-                      )}
-                    </motion.button>
-                  );
-                })}
-              </AnimatePresence>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-1.5">
+              {filtered.map(hero => {
+                const isSelected = selectedIds.has(hero.id);
+                const disabled = isFull && !isSelected;
+                return (
+                  <div
+                    key={hero.id}
+                    className={disabled ? 'opacity-40 cursor-not-allowed' : ''}
+                  >
+                    <HeroCard
+                      hero={hero}
+                      compact
+                      selected={isSelected}
+                      onClick={disabled ? undefined : () => onSelect(hero)}
+                    />
+                  </div>
+                );
+              })}
             </div>
           )}
-        </div>
-
-        <div className="pt-4 border-t flex items-center justify-between">
-          <div className="font-pixel text-[8px] text-muted-foreground">
-            <span className="text-game-energy-green">{eligibleHeroes.length}</span> éligible(s)
-            {' • '}
-            <span>{ineligibleHeroes.length}</span> non éligible(s)
-          </div>
         </div>
       </DialogContent>
     </Dialog>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,6 +15,7 @@ import SummonModal from '@/components/SummonModal';
 import HeroUpgradeModal from '@/components/HeroUpgradeModal';
 import HeroDetailInline from '@/components/HeroDetailInline';
 import HeroPickerModal from '@/components/HeroPickerModal';
+import FusionHeroPickerModal from '@/components/FusionHeroPickerModal';
 import FusionSlot from '@/components/FusionSlot';
 import StoryMode from '@/components/StoryMode';
 import { GameState, Hero, MAP_CONFIGS, PlayerData, RARITY_CONFIG, RARITY_ORDER, sortByRarity, Rarity, HERO_NAMES, HERO_FAMILIES, HERO_FAMILY_MAP, HeroFamilyId, MAX_LEVEL_BY_RARITY } from '@/game/types';
@@ -120,6 +121,10 @@ const Index = () => {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
   const [heroFilters, setHeroFilters] = useState<HeroFilters>(DEFAULT_HERO_FILTERS);
   const [codexClanFilter, setCodexClanFilter] = useState<'all' | HeroFamilyId>('all');
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [pickerSlotIdx, setPickerSlotIdx] = useState<number | null>(null);
+  const [presetSaveOpen, setPresetSaveOpen] = useState(false);
+  const [presetSaveName, setPresetSaveName] = useState('');
 
   // Tutorial — check for restart flag from Profile page
   useEffect(() => {
@@ -1029,6 +1034,17 @@ const Index = () => {
     setSelectedHeroes(new Set(sorted.slice(0, 6).map(h => h.id)));
   };
 
+  const handlePickerSelect = (hero: Hero) => {
+    if (pickerSlotIdx === null) return;
+    const currentIds = Array.from(selectedHeroes);
+    if (currentIds[pickerSlotIdx]) {
+      setSelectedHeroes(prev => { const s = new Set(prev); s.delete(currentIds[pickerSlotIdx]); return s; });
+    }
+    setSelectedHeroes(prev => { const s = new Set(prev); s.add(hero.id); return s; });
+    setPickerOpen(false);
+    setPickerSlotIdx(null);
+  };
+
   const handleUpgrade = (heroId: string) => {
     const hero = player.heroes.find(h => h.id === heroId);
     if (!hero || hero.level >= 10) return;
@@ -1846,89 +1862,116 @@ const Index = () => {
                       {Array.from({ length: 6 }).map((_, slotIdx) => {
                         const heroId = Array.from(selectedHeroes)[slotIdx];
                         const hero = heroId ? player.heroes.find(h => h.id === heroId) : null;
-                        return (
+                        return hero ? (
                           <div
                             key={slotIdx}
-                            className={`pixel-border p-2 flex flex-col items-center justify-center min-h-[72px] transition-all ${
-                              hero ? `bg-card rarity-${hero.rarity}` : 'bg-muted/30 border-dashed'
-                            }`}
+                            className={`pixel-border p-2 flex flex-col items-center justify-center min-h-[72px] transition-all cursor-pointer bg-card rarity-${hero.rarity}`}
+                            onClick={() => { setPickerSlotIdx(slotIdx); setPickerOpen(true); }}
                           >
-                            {hero ? (
-                              <>
-                                <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={32} />
-                                <p className="font-pixel text-[7px] text-foreground mt-1 truncate max-w-[60px]">{hero.name.split(' ')[0]}</p>
-                                <p className="text-[7px] mt-0.5" style={{ color: `hsl(var(--game-rarity-${hero.rarity}))` }}>
-                                  {RARITY_CONFIG[hero.rarity].label}
-                                </p>
-                                <button
-                                  onClick={() => toggleHeroSelection(hero.id)}
-                                  className="text-[7px] text-destructive hover:text-destructive/80 mt-0.5 min-w-[32px] min-h-[32px] flex items-center justify-center"
-                                >
-                                  ✕
-                                </button>
-                              </>
-                            ) : (
-                              <p className="font-pixel text-[7px] text-muted-foreground">Slot {slotIdx + 1}</p>
-                            )}
+                            <HeroAvatar heroId={hero.id} heroName={hero.name} rarity={hero.rarity} size={32} />
+                            <p className="font-pixel text-[7px] text-foreground mt-1 truncate max-w-[60px]">{hero.name.split(' ')[0]}</p>
+                            <p className="text-[7px] mt-0.5" style={{ color: `hsl(var(--game-rarity-${hero.rarity}))` }}>
+                              {RARITY_CONFIG[hero.rarity].label}
+                            </p>
+                            <button
+                              onClick={e => { e.stopPropagation(); toggleHeroSelection(hero.id); }}
+                              className="text-[7px] text-destructive hover:text-destructive/80 mt-0.5 min-w-[32px] min-h-[32px] flex items-center justify-center"
+                            >
+                              ✕
+                            </button>
                           </div>
+                        ) : (
+                          <button
+                            key={slotIdx}
+                            onClick={() => { setPickerSlotIdx(slotIdx); setPickerOpen(true); }}
+                            className="pixel-border p-2 flex flex-col items-center justify-center min-h-[72px] transition-all cursor-pointer border-dashed bg-muted/30 hover:bg-muted/50"
+                          >
+                            <span className="font-pixel text-[18px] text-muted-foreground leading-none">+</span>
+                            <p className="font-pixel text-[7px] text-muted-foreground mt-1">Slot {slotIdx + 1}</p>
+                          </button>
                         );
                       })}
                     </div>
 
-                    {/* Charger un preset */}
-                    <div className="pixel-border bg-muted/20 rounded p-3">
-                      <p className="font-pixel text-[8px] text-muted-foreground mb-2 flex items-center gap-1.5">
-                        <Play size={10} /> Charger une équipe sauvegardée
-                      </p>
-                      {teamPresets.some(p => p.heroIds.length > 0) ? (
-                        <div className="flex gap-2 flex-wrap">
-                          {teamPresets.filter(p => p.heroIds.length > 0).map(preset => (
-                            <button
-                              key={preset.id}
-                              onClick={() => {
-                                setSelectedHeroes(new Set(preset.heroIds));
-                                toast(`${preset.name} chargée !`);
-                              }}
-                              className="pixel-btn pixel-btn-secondary font-pixel text-[7px] px-2 py-1 flex items-center gap-1"
-                            >
-                              <Play size={10} /> {preset.name} ({preset.heroIds.length})
-                            </button>
-                          ))}
+                    {activeClanSkills.length > 0 && (
+                      <div className="mt-2 space-y-1 mb-3">
+                        <p className="font-pixel text-[7px] text-primary">✨ SYNERGIES</p>
+                        {activeClanSkills.map((s, i) => (
+                          <p key={i} className="text-[8px] text-foreground flex items-center gap-1">
+                            <span className="text-primary">▸</span> {s.name} — {s.description}
+                          </p>
+                        ))}
+                      </div>
+                    )}
+
+                    <div className="flex flex-wrap items-center gap-2 mb-3">
+                      {teamPresets.filter(p => p.heroIds.length > 0).map(preset => (
+                        <button
+                          key={preset.id}
+                          onClick={() => { setSelectedHeroes(new Set(preset.heroIds)); toast(`${preset.name} chargée !`); }}
+                          className="font-pixel text-[7px] px-2 py-1 rounded bg-muted/50 border border-border hover:bg-muted transition-colors flex items-center gap-1"
+                        >
+                          <Play size={9} /> {preset.name}
+                        </button>
+                      ))}
+                      {selectedHeroes.size > 0 && !presetSaveOpen && (
+                        <button
+                          onClick={() => setPresetSaveOpen(true)}
+                          className="font-pixel text-[7px] px-2 py-1 rounded bg-muted/50 border border-border hover:bg-muted transition-colors"
+                        >
+                          💾 Sauvegarder
+                        </button>
+                      )}
+                      {presetSaveOpen && (
+                        <div className="flex items-center gap-1">
+                          <input
+                            autoFocus
+                            value={presetSaveName}
+                            onChange={e => setPresetSaveName(e.target.value)}
+                            placeholder="Nom de l'équipe"
+                            maxLength={24}
+                            className="font-pixel text-[7px] px-2 py-1 rounded bg-muted border border-border text-foreground outline-none w-32"
+                          />
+                          <button
+                            onClick={() => {
+                              if (!presetSaveName.trim()) return;
+                              const name = presetSaveName.trim();
+                              setTeamPresets(prev => {
+                                const emptySlot = prev.find(p => p.heroIds.length === 0);
+                                if (emptySlot) {
+                                  return prev.map(p => p.id === emptySlot.id ? { ...p, name, heroIds: Array.from(selectedHeroes) } : p);
+                                }
+                                if (prev.length < 6) {
+                                  return [...prev, { id: `team-${Date.now()}`, name, heroIds: Array.from(selectedHeroes) }];
+                                }
+                                return prev.map((p, i) => i === prev.length - 1 ? { ...p, name, heroIds: Array.from(selectedHeroes) } : p);
+                              });
+                              toast(`"${name}" sauvegardée !`);
+                              setPresetSaveOpen(false);
+                              setPresetSaveName('');
+                            }}
+                            className="font-pixel text-[7px] px-2 py-1 rounded bg-primary/20 text-primary hover:bg-primary/30 transition-colors"
+                          >
+                            OK
+                          </button>
+                          <button
+                            onClick={() => { setPresetSaveOpen(false); setPresetSaveName(''); }}
+                            className="font-pixel text-[7px] px-2 py-1 rounded bg-muted text-muted-foreground hover:bg-muted/80 transition-colors"
+                          >
+                            ✕
+                          </button>
                         </div>
-                      ) : (
-                        <p className="font-pixel text-[8px] text-muted-foreground/60">Aucun preset — sauvegarde une équipe dans l'onglet Héros &gt; Équipes</p>
                       )}
                     </div>
 
-                    <details className="pixel-border bg-muted/20 rounded">
-                      <summary className="font-pixel text-[8px] text-muted-foreground cursor-pointer px-3 py-2 flex items-center gap-1.5 hover:text-foreground transition-colors">
-                        <Users size={10} /> Choisir manuellement ({player.heroes.length} héros disponibles)
-                      </summary>
-                      <div className="p-2 grid grid-cols-1 sm:grid-cols-2 gap-1.5 max-h-60 overflow-y-auto">
-                        {player.heroes.sort(sortByRarity).map(hero => (
-                          <HeroCard
-                            key={hero.id}
-                            hero={hero}
-                            compact
-                            selected={selectedHeroes.has(hero.id)}
-                            onClick={() => toggleHeroSelection(hero.id)}
-                          />
-                        ))}
-                      </div>
-                    </details>
+                    <HeroPickerModal
+                      open={pickerOpen}
+                      heroes={player.heroes}
+                      selectedIds={selectedHeroes}
+                      onSelect={handlePickerSelect}
+                      onClose={() => { setPickerOpen(false); setPickerSlotIdx(null); }}
+                    />
                   </div>
-
-                  {/* Synergies actives */}
-                  {activeClanSkills.length > 0 && (
-                    <div className="pixel-border bg-primary/5 p-3 space-y-1 mb-3">
-                      <p className="font-pixel text-[8px] text-primary mb-2">✨ SYNERGIES ACTIVES</p>
-                      {activeClanSkills.map((skill, i) => (
-                        <p key={i} className="text-[8px] text-foreground flex items-center gap-1.5">
-                          <span className="text-primary">▸</span> {skill.name} — {skill.description}
-                        </p>
-                      ))}
-                    </div>
-                  )}
 
                   <button onClick={startTreasureHunt} className="pixel-btn pixel-btn-gold w-full font-pixel text-xs flex items-center justify-center gap-2">
                     <Swords size={16} /> LANCER LA CHASSE !
@@ -2472,7 +2515,7 @@ const Index = () => {
         pityCounters={player.pityCounters}
       />
 
-      <HeroPickerModal
+      <FusionHeroPickerModal
         isOpen={heroPickerOpen}
         onClose={() => setHeroPickerOpen(false)}
         onSelect={handleHeroSelect}


### PR DESCRIPTION
## Résumé

Refonte complète de l'interface de sélection d'équipe avant combat (Chasse au Trésor).

## Changements

### Nouveaux composants
- **`HeroPickerModal.tsx`** (réécrit) — modal de sélection avec filtres rareté + clan, tri par niveau, grille HeroCard
- **`FusionHeroPickerModal.tsx`** (nouveau) — l'ancienne logique du picker de fusion extraite dans son propre composant

### Interface équipe (Index.tsx)
- **Slots cliquables** : slot vide → `+` → ouvre le picker. Slot plein → clic pour remplacer, ✕ pour retirer
- **Synergies clan** affichées directement sous la grille de slots (en temps réel)
- **Presets discrets** : boutons horizontaux compacts pour charger, formulaire inline pour sauvegarder (max 6)
- Section "Charger une équipe" masquée si aucun preset n'existe
- `<details>` "Choisir manuellement" supprimé — remplacé par le picker modal
- Bouton "Auto-sélection" conservé

## Test

1. Aller sur l'onglet Combat → Chasse au Trésor
2. Cliquer sur un slot vide → picker modal s'ouvre avec filtres clan/rareté ✅
3. Sélectionner des héros du même clan → synergies apparaissent sous les slots ✅
4. Sauvegarder comme preset → apparaît dans les boutons discrets ✅
5. Recharger → preset disponible et chargeable ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)