### PR TITLE
feat(v1.3): validation roster 6×6 — tests + corrections

### DIFF
--- a/src/game/summoning.ts
+++ b/src/game/summoning.ts
@@ -58,7 +58,7 @@ const SKILL_POOL_BY_RARITY: Record<Rarity, string[]> = {
   ],
 };
 
-const CANONICAL_HERO_POOL_BY_RARITY: Record<Rarity, { id: string; name: string; iconKey: string }[]> = {
+export const CANONICAL_HERO_POOL_BY_RARITY: Record<Rarity, { id: string; name: string; iconKey: string }[]> = {
   common: [],
   rare: [],
   'super-rare': [],

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -221,9 +221,9 @@ export type HeroFamilyId = typeof HERO_FAMILIES[number]['id'];
 export const HERO_FAMILY_MAP: Record<string, HeroFamilyId> = {
   blaze: 'ember-clan', ember: 'ember-clan', pyro: 'ember-clan', fuse: 'ember-clan', blast: 'ember-clan', sol: 'ember-clan',
   spark: 'storm-riders', volt: 'storm-riders', storm: 'storm-riders', zap: 'storm-riders', vega: 'storm-riders', dash: 'storm-riders',
-  flint: 'forge-guard', rex: 'forge-guard', atlas: 'forge-guard', duke: 'forge-guard', max: 'forge-guard',
-  ash: 'shadow-core', nova: 'shadow-core', echo: 'shadow-core', crash: 'shadow-core', luna: 'shadow-core',
-  pixel: 'arcane-circuit', chip: 'arcane-circuit', byte: 'arcane-circuit', orion: 'arcane-circuit',
+  flint: 'forge-guard', rex: 'forge-guard', atlas: 'forge-guard', duke: 'forge-guard', max: 'forge-guard', brick: 'forge-guard',
+  ash: 'shadow-core', nova: 'shadow-core', echo: 'shadow-core', crash: 'shadow-core', luna: 'shadow-core', shade: 'shadow-core',
+  pixel: 'arcane-circuit', chip: 'arcane-circuit', byte: 'arcane-circuit', orion: 'arcane-circuit', glitch: 'arcane-circuit', rune: 'arcane-circuit',
   boom: 'wild-pack', nitro: 'wild-pack', rush: 'wild-pack', flash: 'wild-pack', jet: 'wild-pack', ace: 'wild-pack',
 };
 

--- a/src/test/rosterValidation.test.ts
+++ b/src/test/rosterValidation.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Tests de validation du roster 6×6 (issue #162)
+ *
+ * Vérifie que les 36 héros (6 clans × 6) sont cohérents
+ * entre HERO_NAMES, HERO_FAMILY_MAP, HERO_VISUALS et BESTIARY_BOMBERS.
+ */
+import { describe, it, expect } from 'vitest';
+import { HERO_NAMES, HERO_FAMILY_MAP, HERO_VISUALS, HERO_FAMILIES } from '../game/types';
+import { BESTIARY_BOMBERS } from '../data/bestiary';
+import { CANONICAL_HERO_POOL_BY_RARITY } from '../game/summoning';
+
+const TOTAL_HEROES = 36;
+const HEROES_PER_CLAN = 6;
+const TOTAL_CLANS = 6;
+
+// ─── 1. HERO_NAMES ────────────────────────────────────────────────────────────
+
+describe('HERO_NAMES', () => {
+  it(`contient exactement ${TOTAL_HEROES} héros`, () => {
+    expect(HERO_NAMES).toHaveLength(TOTAL_HEROES);
+  });
+
+  it('ne contient pas de doublons', () => {
+    const unique = new Set(HERO_NAMES.map(n => n.toLowerCase()));
+    expect(unique.size).toBe(HERO_NAMES.length);
+  });
+
+  it('chaque nom est une chaîne non vide', () => {
+    for (const name of HERO_NAMES) {
+      expect(typeof name).toBe('string');
+      expect(name.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── 2. HERO_FAMILY_MAP ───────────────────────────────────────────────────────
+
+describe('HERO_FAMILY_MAP', () => {
+  it(`contient exactement ${TOTAL_HEROES} entrées`, () => {
+    const keys = Object.keys(HERO_FAMILY_MAP);
+    expect(keys).toHaveLength(TOTAL_HEROES);
+  });
+
+  it(`chaque clan a exactement ${HEROES_PER_CLAN} héros`, () => {
+    const countByClan: Record<string, number> = {};
+    for (const family of Object.values(HERO_FAMILY_MAP)) {
+      countByClan[family] = (countByClan[family] ?? 0) + 1;
+    }
+
+    for (const clan of HERO_FAMILIES) {
+      expect(countByClan[clan.id]).toBe(HEROES_PER_CLAN);
+    }
+  });
+
+  it(`contient exactement ${TOTAL_CLANS} clans distincts`, () => {
+    const clans = new Set(Object.values(HERO_FAMILY_MAP));
+    expect(clans.size).toBe(TOTAL_CLANS);
+  });
+
+  it('chaque héros de HERO_NAMES a une entrée dans HERO_FAMILY_MAP', () => {
+    for (const name of HERO_NAMES) {
+      const key = name.toLowerCase();
+      expect(HERO_FAMILY_MAP).toHaveProperty(key);
+    }
+  });
+
+  it('les héros de la PR #340 (Brick, Shade, Glitch, Rune) sont présents', () => {
+    expect(HERO_FAMILY_MAP.brick).toBe('forge-guard');
+    expect(HERO_FAMILY_MAP.shade).toBe('shadow-core');
+    expect(HERO_FAMILY_MAP.glitch).toBe('arcane-circuit');
+    expect(HERO_FAMILY_MAP.rune).toBe('arcane-circuit');
+  });
+});
+
+// ─── 3. HERO_VISUALS ──────────────────────────────────────────────────────────
+
+describe('HERO_VISUALS', () => {
+  it(`contient exactement ${TOTAL_HEROES} entrées`, () => {
+    const keys = Object.keys(HERO_VISUALS);
+    expect(keys).toHaveLength(TOTAL_HEROES);
+  });
+
+  it('chaque héros de HERO_NAMES a une entrée dans HERO_VISUALS', () => {
+    for (const name of HERO_NAMES) {
+      const key = name.toLowerCase();
+      expect(HERO_VISUALS).toHaveProperty(key);
+    }
+  });
+
+  it('la famille dans HERO_VISUALS est cohérente avec HERO_FAMILY_MAP', () => {
+    for (const [heroKey, visual] of Object.entries(HERO_VISUALS)) {
+      const familyFromMap = HERO_FAMILY_MAP[heroKey];
+      expect(familyFromMap).toBeDefined();
+      expect(visual.family).toBe(familyFromMap);
+    }
+  });
+
+  it('chaque entrée a des traits visuels valides', () => {
+    const validHelmetStyles = ['standard', 'horned', 'crowned', 'tech', 'mask'];
+    for (const [, visual] of Object.entries(HERO_VISUALS)) {
+      expect(validHelmetStyles).toContain(visual.traits.helmetStyle);
+      expect(typeof visual.traits.cape).toBe('boolean');
+      expect(typeof visual.traits.wings).toBe('boolean');
+      expect(typeof visual.traits.aura).toBe('boolean');
+      expect(visual.traits.accentColor).toMatch(/^#[0-9A-Fa-f]{6}$/);
+    }
+  });
+});
+
+// ─── 4. BESTIARY_BOMBERS ──────────────────────────────────────────────────────
+
+describe('BESTIARY_BOMBERS', () => {
+  it(`contient exactement ${TOTAL_HEROES} entrées`, () => {
+    expect(BESTIARY_BOMBERS).toHaveLength(TOTAL_HEROES);
+  });
+
+  it("ne contient pas de doublons d'id", () => {
+    const ids = BESTIARY_BOMBERS.map(b => b.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('chaque héros de HERO_NAMES est présent dans BESTIARY_BOMBERS', () => {
+    const bestiaryIds = new Set(BESTIARY_BOMBERS.map(b => b.id));
+    for (const name of HERO_NAMES) {
+      expect(bestiaryIds.has(name.toLowerCase())).toBe(true);
+    }
+  });
+
+  it('chaque bomber a une rareté définie', () => {
+    for (const bomber of BESTIARY_BOMBERS) {
+      expect(bomber.rarity).toBeDefined();
+    }
+  });
+
+  it('la familyId de chaque bomber correspond à HERO_FAMILY_MAP', () => {
+    for (const bomber of BESTIARY_BOMBERS) {
+      const expectedFamily = HERO_FAMILY_MAP[bomber.id];
+      expect(expectedFamily).toBeDefined();
+      expect(bomber.familyId).toBe(expectedFamily);
+    }
+  });
+});
+
+// ─── 5. CANONICAL_HERO_POOL_BY_RARITY ─────────────────────────────────────────
+
+describe('CANONICAL_HERO_POOL_BY_RARITY', () => {
+  it(`couvre les ${TOTAL_HEROES} héros (chaque héros dans au moins 1 rareté)`, () => {
+    const coveredIds = new Set<string>();
+    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
+      for (const hero of pool) {
+        coveredIds.add(hero.id);
+      }
+    }
+    expect(coveredIds.size).toBe(TOTAL_HEROES);
+  });
+
+  it("ne contient pas de doublons dans une même rareté", () => {
+    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
+      const ids = pool.map(h => h.id);
+      const unique = new Set(ids);
+      expect(unique.size).toBe(ids.length);
+    }
+  });
+
+  it('chaque héros du pool a un id, un name et un iconKey valides', () => {
+    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
+      for (const hero of pool) {
+        expect(typeof hero.id).toBe('string');
+        expect(hero.id.length).toBeGreaterThan(0);
+        expect(typeof hero.name).toBe('string');
+        expect(hero.name.length).toBeGreaterThan(0);
+        expect(typeof hero.iconKey).toBe('string');
+        expect(hero.iconKey.length).toBeGreaterThan(0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Correction incohérence** : `HERO_FAMILY_MAP` dans `types.ts` n'avait que 32 entrées — Brick, Shade, Glitch et Rune (ajoutés par PR #340) étaient présents dans `HERO_NAMES` et `HERO_VISUALS` mais absents de `HERO_FAMILY_MAP`, ce qui causait des `undefined` à la création des héros via le gacha
- **Export** : `CANONICAL_HERO_POOL_BY_RARITY` dans `summoning.ts` rendu public pour permettre les tests
- **Tests** : ajout de `src/test/rosterValidation.test.ts` (20 tests) couvrant les 4 constantes du roster

## Tests ajoutés

- `HERO_NAMES` : 36 entrées, sans doublons, noms non vides
- `HERO_FAMILY_MAP` : 36 entrées, exactement 6 clans × 6 héros, présence des héros PR #340
- `HERO_VISUALS` : 36 entrées, cohérence famille↔HERO_FAMILY_MAP, traits visuels valides
- `BESTIARY_BOMBERS` : 36 entrées, familyId cohérente avec HERO_FAMILY_MAP
- `CANONICAL_HERO_POOL_BY_RARITY` : couverture complète des 36 héros

Closes #162

🤖 Generated with Claude Code