### PR TITLE
feat(v1.3): Game Modes — Ascension prototype + design docs

### DIFF
--- a/docs/design/ascension-mode.md
+++ b/docs/design/ascension-mode.md
@@ -1,0 +1,108 @@
+# Mode Ascension — Design Document
+
+**Version :** 0.1 (prototype)
+**Statut :** Feature flag `ascension: false` — non livré en prod
+**Issue :** #165
+
+---
+
+## Concept
+
+Le Mode Ascension est un mode de jeu roguelite dans lequel le joueur gravit une tour de 10 étages, chaque palier ajoutant un nouveau modificateur et renforçant les ennemis. L'objectif est de monter le plus haut possible en une seule run, sans pouvoir recommencer depuis le milieu.
+
+- Sessions courtes : 5 à 15 minutes
+- Replayability élevée grâce à la combinaison aléatoire de modificateurs
+- Récompenses en Universal Shards proportionnelles à l'étage atteint
+- Record personnel affiché pour encourager l'amélioration
+
+---
+
+## Mécaniques
+
+### Structure d'une run
+
+1. Le joueur sélectionne son équipe (mêmes héros que Story Mode).
+2. L'étage 1 démarre avec des ennemis de difficulté standard.
+3. Chaque étage vaincu débloque l'étage suivant et applique **un nouveau modificateur**.
+4. La run se termine si l'équipe est éliminée ou si le joueur abandonne.
+5. Les récompenses sont attribuées selon l'étage **le plus haut atteint**.
+
+### Scaling des ennemis par étage
+
+| Etage | HP ennemis | Vitesse ennemis | Modificateur |
+|-------|-----------|-----------------|--------------|
+| 1     | x1.00     | x1.00           | Aucun        |
+| 2     | x1.15     | x1.10           | Bombes double explosion   |
+| 3     | x1.32     | x1.21           | Coffres aléatoires        |
+| 4     | x1.52     | x1.33           | Ennemis régénèrent        |
+| 5     | x1.75     | x1.46           | Bombes à timer court      |
+| 6     | x2.01     | x1.61           | Obscurité partielle       |
+| 7     | x2.31     | x1.77           | Ennemis posent des bombes |
+| 8     | x2.66     | x1.95           | Coffres piégés            |
+| 9     | x3.06     | x2.14           | Double vague d'ennemis    |
+| 10    | x3.52     | x2.36           | Chaos total (tous mods)   |
+
+Formule : HP_multiplicateur = 1.15^(étage - 1), Vitesse_multiplicateur = 1.10^(étage - 1)
+
+---
+
+## Modificateurs
+
+Chaque étage (sauf le 1) ajoute un modificateur permanent pour le reste de la run.
+
+| Id | Nom | Description |
+|----|-----|-------------|
+| `double_explosion` | Bombes double explosion | Chaque bombe déclenche 2 explosions successives (+0.5s entre les deux) |
+| `random_chests` | Coffres aléatoires | Des coffres apparaissent à des positions aléatoires pendant le combat |
+| `regen_enemies` | Ennemis régénèrent | Les ennemis récupèrent 2% de leurs HP max par seconde |
+| `short_fuse` | Mèche courte | Le timer des bombes est réduit de 40% |
+| `darkness` | Obscurité partielle | La visibilité autour de chaque héros est limitée à 3 tuiles |
+| `bombing_enemies` | Ennemis poseurs | Les ennemis posent des bombes toutes les 5 secondes |
+| `trapped_chests` | Coffres piégés | 50% des coffres déclenchent une explosion à l'ouverture |
+| `double_wave` | Double vague | Deux vagues d'ennemis arrivent simultanément |
+| `chaos` | Chaos total | Tous les modificateurs précédents sont actifs en même temps |
+
+---
+
+## Récompenses
+
+Les Universal Shards sont attribuées selon l'étage le plus haut atteint. Les récompenses ne sont données qu'**une seule fois par run** (pas de farming par abandon).
+
+| Etage atteint | Universal Shards |
+|---------------|-----------------|
+| 1             | 5               |
+| 2             | 12              |
+| 3             | 22              |
+| 4             | 35              |
+| 5             | 55              |
+| 6             | 80              |
+| 7             | 110             |
+| 8             | 150             |
+| 9             | 200             |
+| 10            | 300             |
+
+### Record personnel
+
+- Le record de l'étage le plus haut atteint est affiché dans l'UI.
+- Un badge "Conquérant Niveau X" est attribué selon le record.
+- Le record est sauvegardé en localStorage + Supabase (colonne à ajouter : `ascension_best_floor`).
+
+---
+
+## KPIs cibles
+
+| Indicateur | Cible |
+|------------|-------|
+| Durée session moyenne | 5 – 15 min |
+| Taux de relance (run suivante) | > 60% |
+| Etage moyen atteint (joueurs actifs) | 4 – 6 |
+| Diversité builds utilisés | > 3 combinaisons héros fréquentes |
+
+---
+
+## Notes d'implémentation
+
+- Les modificateurs s'appuient sur le système d'état existant dans `engine.ts` — prévoir un champ `ascensionModifiers: AscensionModifierId[]` dans `GameState`.
+- Le scaling HP/vitesse se fait avant `spawnEnemy()` en multipliant les valeurs de base.
+- La progression (étage courant, modificateurs actifs) est stockée localement pendant la run, pas en base de données (run non sauvegardable en cours).
+- Feature flag : `GAME_MODE_FLAGS.ascension` doit être `true` pour activer le mode.

--- a/docs/design/world-boss-mode.md
+++ b/docs/design/world-boss-mode.md
@@ -1,0 +1,135 @@
+# Mode World Boss — Design Document
+
+**Version :** 0.1 (prototype)
+**Statut :** Feature flag `worldBoss: false` — non livré en prod
+**Issue :** #165
+
+---
+
+## Concept
+
+Le Mode World Boss est un event communautaire asynchrone : tous les joueurs actifs partagent un même boss géant à abattre collectivement dans une fenêtre de 72 heures. Chaque joueur contribue en infligeant des dégâts via des combats individuels, et la progression est partagée globalement.
+
+Ce mode vise à :
+- Créer un sentiment de communauté et d'effort collectif
+- Générer un FOMO naturel (fenêtre limitée, récompenses exclusives)
+- Encourager la connexion quotidienne (paliers de dégâts individuels)
+
+---
+
+## Mécanique
+
+### Déroulement d'un event
+
+1. Un World Boss apparaît toutes les **2 semaines** (ou déclenché manuellement côté admin).
+2. La fenêtre de participation dure **72 heures**.
+3. Chaque joueur peut attaquer le boss **3 fois par jour** (rechargement à minuit UTC).
+4. Chaque attaque lance un combat Bomberman standard — les dégâts infligés s'accumulent.
+5. Quand les HP collectifs du boss tombent à 0, l'event se termine et toutes les récompenses de palier sont distribuées.
+6. Si le boss n'est pas vaincu en 72h, les paliers atteints sont quand même récompensés.
+
+### Calcul des dégâts
+
+- Dégâts par attaque = (Puissance moyenne de l'équipe) x (ennemis tués) x (multiplicateur de difficulté)
+- Les dégâts sont envoyés à Supabase à la fin de chaque combat via une fonction RPC `add_boss_damage(player_id, damage_amount)`.
+- Un leaderboard individuel affiche le top 10 des contributeurs.
+
+### HP du boss
+
+- HP total = 10 000 000 (base) x (nombre de joueurs actifs au lancement)
+- Ajustement dynamique pour maintenir un défi raisonnable (~60% de chance de victoire collective).
+
+---
+
+## Progression partagée — Paliers
+
+Les paliers sont débloqués quand la barre de vie collective du boss atteint certains seuils. Tous les joueurs ayant participé (au moins 1 attaque) reçoivent les récompenses des paliers atteints.
+
+| Palier | HP boss restants | Récompense (tous participants) |
+|--------|-----------------|-------------------------------|
+| 1      | 75% vaincus     | 50 Universal Shards + badge "Blesseur" |
+| 2      | 50% vaincus     | 120 Universal Shards + titre "Guerrier du Boss" |
+| 3      | 75% vaincus     | 250 Universal Shards + skin exclusif event |
+| 4      | 100% vaincus    | 500 Universal Shards + héros event exclusif (si dispo) |
+
+### Récompenses individuelles (contribution personnelle)
+
+| Contribution personnelle | Bonus |
+|--------------------------|-------|
+| Top 10% des dégâts       | +100 Universal Shards |
+| Top 1% des dégâts        | +300 Universal Shards + badge exclusif |
+
+---
+
+## Interface joueur
+
+### Pendant l'event
+
+- Bannière persistante dans le hub principal avec countdown 72h.
+- Barre HP globale du boss mise à jour toutes les 30 secondes (polling Supabase).
+- Bouton "Attaquer" avec compteur d'attaques restantes aujourd'hui.
+- Leaderboard des 10 meilleurs contributeurs.
+- Historique des dégâts personnels pour la session.
+
+### Après l'event
+
+- Résumé de l'event : boss vaincu ou non, paliers atteints, contribution personnelle.
+- Attribution automatique des récompenses dans l'inventaire.
+- Archive des events passés (boss name, date, résultat).
+
+---
+
+## Architecture technique (ébauche)
+
+### Tables Supabase à créer
+
+```sql
+-- Event actif
+world_boss_events (
+  id uuid PRIMARY KEY,
+  boss_name text,
+  boss_hp_total bigint,
+  boss_hp_remaining bigint,
+  started_at timestamptz,
+  ends_at timestamptz,
+  status text -- 'active' | 'completed' | 'failed'
+)
+
+-- Contributions individuelles
+world_boss_contributions (
+  id uuid PRIMARY KEY,
+  event_id uuid REFERENCES world_boss_events(id),
+  player_id uuid REFERENCES auth.users(id),
+  total_damage bigint,
+  attacks_today int,
+  last_attack_at timestamptz
+)
+```
+
+### RPC Supabase
+
+- `get_active_world_boss()` — retourne l'event en cours (ou null)
+- `add_boss_damage(event_id, damage)` — incrémente les dégâts joueur + boss
+- `get_boss_leaderboard(event_id)` — top 10 contributeurs
+
+---
+
+## KPIs cibles
+
+| Indicateur | Cible |
+|------------|-------|
+| Participation (% joueurs actifs) | > 70% pendant la fenêtre 72h |
+| Attaques quotidiennes (DAU) | +40% vs moyenne hors event |
+| Taux de victoire collective | ~60% des events |
+| Retention J+1 pendant event | > 55% |
+| FOMO mesuré (connexions J+3) | pic > 2x moyenne |
+
+---
+
+## Notes de design
+
+- Le nombre d'attaques journalières (3) est volontairement limité pour étaler la participation et maximiser le FOMO.
+- Les récompenses exclusives (skins, héros event) doivent être suffisamment désirables pour motiver les joueurs inactifs.
+- Prévoir une notification push / email optionnelle à J-24h de la fin de l'event.
+- Le boss doit avoir un design visuel distinct et mémorable (nom propre : ex. "Moloch l'Éternel", "La Reine des Abysses").
+- Feature flag : `GAME_MODE_FLAGS.worldBoss` doit être `true` pour activer le mode.

--- a/src/components/AscensionMode.tsx
+++ b/src/components/AscensionMode.tsx
@@ -1,0 +1,155 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Lock, TrendingUp, Star, Zap } from 'lucide-react';
+import {
+  GAME_MODE_FLAGS,
+  ASCENSION_FLOORS,
+  ASCENSION_MODIFIERS,
+  getAscensionModifier,
+  AscensionFloor,
+} from '@/game/gameModes';
+
+interface AscensionModeProps {
+  bestFloor?: number;
+  onStart?: () => void;
+}
+
+const FLOOR_BADGE_COLORS: Record<number, string> = {
+  1:  'bg-gray-700 text-gray-200',
+  2:  'bg-gray-700 text-gray-200',
+  3:  'bg-green-900 text-green-300',
+  4:  'bg-green-900 text-green-300',
+  5:  'bg-blue-900 text-blue-300',
+  6:  'bg-blue-900 text-blue-300',
+  7:  'bg-purple-900 text-purple-300',
+  8:  'bg-purple-900 text-purple-300',
+  9:  'bg-orange-900 text-orange-300',
+  10: 'bg-red-900 text-red-300',
+};
+
+const FloorCard: React.FC<{ floor: AscensionFloor; isBestFloor: boolean }> = ({ floor, isBestFloor }) => {
+  const modifier = floor.modifierId ? getAscensionModifier(floor.modifierId) : null;
+  const badgeColor = FLOOR_BADGE_COLORS[floor.floor] ?? 'bg-gray-700 text-gray-200';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -10 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ delay: floor.floor * 0.04 }}
+      className={`pixel-border p-3 flex items-center gap-3 ${isBestFloor ? 'ring-2 ring-yellow-400' : ''}`}
+    >
+      <div className={`font-pixel text-[9px] px-2 py-1 rounded ${badgeColor} min-w-[40px] text-center`}>
+        {floor.floor < 10 ? `0${floor.floor}` : floor.floor}
+      </div>
+
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-pixel text-[8px] text-foreground truncate">{floor.name}</span>
+          {isBestFloor && (
+            <span className="font-pixel text-[7px] text-yellow-400 flex items-center gap-1">
+              <Star size={8} className="fill-yellow-400" /> Record
+            </span>
+          )}
+        </div>
+        {modifier ? (
+          <p className="font-pixel text-[7px] text-muted-foreground mt-0.5 truncate">
+            <Zap size={8} className="inline mr-1 text-yellow-400" />
+            {modifier.name}
+          </p>
+        ) : (
+          <p className="font-pixel text-[7px] text-muted-foreground mt-0.5">Pas de modificateur</p>
+        )}
+      </div>
+
+      <div className="text-right shrink-0">
+        <div className="font-pixel text-[7px] text-red-400">HP x{floor.hpMultiplier.toFixed(2)}</div>
+        <div className="font-pixel text-[7px] text-blue-400">SPD x{floor.speedMultiplier.toFixed(2)}</div>
+      </div>
+
+      <div className="shrink-0 text-right">
+        <div className="font-pixel text-[8px] text-yellow-400">{floor.shardReward}</div>
+        <div className="font-pixel text-[6px] text-muted-foreground">Shards</div>
+      </div>
+    </motion.div>
+  );
+};
+
+const AscensionMode: React.FC<AscensionModeProps> = ({ bestFloor = 0, onStart }) => {
+  const isEnabled = GAME_MODE_FLAGS.ascension;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="space-y-4"
+    >
+      <div className="text-center py-4">
+        <h2 className="font-pixel text-sm sm:text-lg text-foreground text-glow-red mb-1 flex items-center justify-center gap-2">
+          <TrendingUp size={20} /> MODE ASCENSION
+        </h2>
+        <p className="font-pixel text-[7px] text-muted-foreground">
+          Gravis la tour — 10 étages, 10 modificateurs, 1 seule chance
+        </p>
+      </div>
+
+      {bestFloor > 0 && (
+        <div className="pixel-border p-3 flex items-center justify-between">
+          <span className="font-pixel text-[8px] text-muted-foreground">Meilleur étage</span>
+          <span className="font-pixel text-[10px] text-yellow-400 flex items-center gap-1">
+            <Star size={12} className="fill-yellow-400" />
+            Étage {bestFloor} / 10
+          </span>
+        </div>
+      )}
+
+      {!isEnabled ? (
+        <div className="pixel-border p-6 text-center space-y-3 bg-muted/30">
+          <Lock size={32} className="mx-auto text-muted-foreground" />
+          <p className="font-pixel text-[9px] text-muted-foreground">COMING SOON</p>
+          <p className="font-pixel text-[7px] text-muted-foreground">
+            Le Mode Ascension est en cours de développement.
+          </p>
+          <button
+            disabled
+            className="pixel-btn pixel-btn-secondary font-pixel text-[8px] w-full opacity-40 cursor-not-allowed"
+          >
+            Commencer la montée
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={onStart}
+          className="pixel-btn font-pixel text-[9px] w-full py-3"
+        >
+          <TrendingUp size={14} className="inline mr-2" />
+          Commencer la montée
+        </button>
+      )}
+
+      <div className="space-y-2">
+        <h3 className="font-pixel text-[8px] text-muted-foreground px-1">Les 10 étages</h3>
+        {ASCENSION_FLOORS.map(floor => (
+          <FloorCard
+            key={floor.floor}
+            floor={floor}
+            isBestFloor={floor.floor === bestFloor}
+          />
+        ))}
+      </div>
+
+      <div className="pixel-border p-4 space-y-2">
+        <h3 className="font-pixel text-[8px] text-foreground mb-3 flex items-center gap-2">
+          <Zap size={12} className="text-yellow-400" /> Modificateurs
+        </h3>
+        {ASCENSION_MODIFIERS.map(mod => (
+          <div key={mod.id} className="flex gap-2">
+            <span className="font-pixel text-[7px] text-yellow-400 shrink-0">{mod.name}</span>
+            <span className="font-pixel text-[6px] text-muted-foreground">{mod.description}</span>
+          </div>
+        ))}
+      </div>
+    </motion.div>
+  );
+};
+
+export default AscensionMode;


### PR DESCRIPTION
## Summary

- Design doc Mode Ascension (10 étages, modificateurs croissants, récompenses en Universal Shards)
- Design doc World Boss (event communautaire 72h, paliers de progression partagée)
- `gameModes.ts` : types TypeScript + constantes (10 floors, 9 modificateurs) + feature flags
- `AscensionMode.tsx` : composant UI prototype feature-flagged (affiche les étages + "Coming soon" si flag off)

## Détail des fichiers

| Fichier | Description |
|---------|-------------|
| `docs/design/ascension-mode.md` | Concept, mécanique de scaling, modificateurs, récompenses, KPIs |
| `docs/design/world-boss-mode.md` | Concept event communautaire, paliers, architecture Supabase, KPIs |
| `src/game/gameModes.ts` | `AscensionFloor`, `AscensionModifier`, `ASCENSION_FLOORS[10]`, `GAME_MODE_FLAGS` |
| `src/components/AscensionMode.tsx` | UI liste des 10 étages avec modificateurs, bouton désactivé si flag off |

## Feature flags

Les deux modes sont désactivés en prod :
```ts
export const GAME_MODE_FLAGS = {
  ascension: false,  // prototype
  worldBoss: false,  // prototype
} as const;
```

## Test plan

- [x] `npm run build` — aucune erreur TypeScript
- [x] Feature flags à `false` — bouton "Commencer" désactivé, message "Coming soon" visible
- [ ] Passer `ascension: true` pour vérifier le rendu complet de l'UI

Closes #165

🤖 Generated with Claude Code