### PR TITLE
feat: pool de héros fixes + identité préservée à la fusion

### DIFF
--- a/src/data/bestiary.ts
+++ b/src/data/bestiary.ts
@@ -1,4 +1,5 @@
-import { HERO_ICON_KEYS, HERO_NAMES, HERO_FAMILIES, Rarity, HERO_VISUALS, HeroFamilyId, getHeroVisualTraits } from '@/game/types';
+import { HERO_FAMILIES, Rarity, HERO_VISUALS, HeroFamilyId, getHeroVisualTraits } from '@/game/types';
+import { HERO_POOL } from '@/game/heroPool';
 
 export type AssetStatus = 'missing' | 'wip' | 'ready';
 
@@ -42,8 +43,8 @@ export interface BestiaryBomber {
   assets: BomberAssetRefs;
 }
 
-const HERO_ICON_BY_NAME = Object.fromEntries(
-  HERO_NAMES.map((heroName, index) => [heroName.toLowerCase(), HERO_ICON_KEYS[index % HERO_ICON_KEYS.length]]),
+const HERO_ICON_BY_TEMPLATE = Object.fromEntries(
+  HERO_POOL.map(t => [t.name.toLowerCase(), t.icon]),
 );
 
 export const BESTIARY_BOMBERS: BestiaryBomber[] = [
@@ -87,7 +88,7 @@ export const BESTIARY_BOMBERS: BestiaryBomber[] = [
   ...bomber,
   assets: {
     ...bomber.assets,
-    iconKey: bomber.assets.iconKey ?? HERO_ICON_BY_NAME[bomber.name.toLowerCase()],
+    iconKey: bomber.assets.iconKey ?? HERO_ICON_BY_TEMPLATE[bomber.name.toLowerCase()] ?? 'bomb',
     visualTraits: getHeroVisualTraits(bomber.id),
   },
 }));

--- a/src/game/heroPool.ts
+++ b/src/game/heroPool.ts
@@ -1,0 +1,54 @@
+import { HeroFamilyId } from './types';
+
+export interface HeroTemplate {
+  templateId: string;
+  name: string;
+  icon: string;   // clé valide de ICON_MAP (bomb|zap|sparkle|star|target|rocket|gamepad|bot|shield|sword|axe|flame|crown|skull|gem|bird)
+  family: HeroFamilyId;
+}
+
+// 6 clans × 6 personnages = 36 templates
+export const HERO_POOL: HeroTemplate[] = [
+  // ember-clan (feu)
+  { templateId: 'blaze', name: 'Blaze', icon: 'flame',  family: 'ember-clan' },
+  { templateId: 'ember', name: 'Ember', icon: 'flame',  family: 'ember-clan' },
+  { templateId: 'pyro',  name: 'Pyro',  icon: 'flame',  family: 'ember-clan' },
+  { templateId: 'fuse',  name: 'Fuse',  icon: 'bomb',   family: 'ember-clan' },
+  { templateId: 'blast', name: 'Blast', icon: 'rocket', family: 'ember-clan' },
+  { templateId: 'sol',   name: 'Sol',   icon: 'star',   family: 'ember-clan' },
+  // storm-riders (électrique)
+  { templateId: 'spark', name: 'Spark', icon: 'zap',     family: 'storm-riders' },
+  { templateId: 'volt',  name: 'Volt',  icon: 'zap',     family: 'storm-riders' },
+  { templateId: 'storm', name: 'Storm', icon: 'sparkle', family: 'storm-riders' },
+  { templateId: 'zappy', name: 'Zappy', icon: 'zap',     family: 'storm-riders' },
+  { templateId: 'vega',  name: 'Vega',  icon: 'star',    family: 'storm-riders' },
+  { templateId: 'dash',  name: 'Dash',  icon: 'rocket',  family: 'storm-riders' },
+  // forge-guard (défense)
+  { templateId: 'flint', name: 'Flint', icon: 'shield', family: 'forge-guard' },
+  { templateId: 'rex',   name: 'Rex',   icon: 'sword',  family: 'forge-guard' },
+  { templateId: 'atlas', name: 'Atlas', icon: 'shield', family: 'forge-guard' },
+  { templateId: 'duke',  name: 'Duke',  icon: 'crown',  family: 'forge-guard' },
+  { templateId: 'maxg',  name: 'Max',   icon: 'axe',    family: 'forge-guard' },
+  { templateId: 'brick', name: 'Brick', icon: 'shield', family: 'forge-guard' },
+  // shadow-core (ombre)
+  { templateId: 'ash',   name: 'Ash',   icon: 'skull',   family: 'shadow-core' },
+  { templateId: 'nova',  name: 'Nova',  icon: 'sparkle', family: 'shadow-core' },
+  { templateId: 'echo',  name: 'Echo',  icon: 'target',  family: 'shadow-core' },
+  { templateId: 'crash', name: 'Crash', icon: 'skull',   family: 'shadow-core' },
+  { templateId: 'luna',  name: 'Luna',  icon: 'star',    family: 'shadow-core' },
+  { templateId: 'shade', name: 'Shade', icon: 'skull',   family: 'shadow-core' },
+  // arcane-circuit (tech)
+  { templateId: 'pixel',  name: 'Pixel',  icon: 'gamepad', family: 'arcane-circuit' },
+  { templateId: 'chip',   name: 'Chip',   icon: 'bot',     family: 'arcane-circuit' },
+  { templateId: 'byte',   name: 'Byte',   icon: 'bot',     family: 'arcane-circuit' },
+  { templateId: 'orion',  name: 'Orion',  icon: 'gem',     family: 'arcane-circuit' },
+  { templateId: 'glitch', name: 'Glitch', icon: 'gamepad', family: 'arcane-circuit' },
+  { templateId: 'rune',   name: 'Rune',   icon: 'gem',     family: 'arcane-circuit' },
+  // wild-pack (rush)
+  { templateId: 'boom',  name: 'Boom',  icon: 'bomb',   family: 'wild-pack' },
+  { templateId: 'nitro', name: 'Nitro', icon: 'rocket', family: 'wild-pack' },
+  { templateId: 'rush',  name: 'Rush',  icon: 'rocket', family: 'wild-pack' },
+  { templateId: 'flash', name: 'Flash', icon: 'zap',    family: 'wild-pack' },
+  { templateId: 'jet',   name: 'Jet',   icon: 'bird',   family: 'wild-pack' },
+  { templateId: 'ace',   name: 'Ace',   icon: 'crown',  family: 'wild-pack' },
+];

--- a/src/game/saveSystem.ts
+++ b/src/game/saveSystem.ts
@@ -10,7 +10,9 @@ const GUEST_TTL_MS = 24 * 60 * 60 * 1000; // 24h
 export function getDefaultPlayerData(): PlayerData {
   const starterHero = generateHero('common');
   starterHero.name = 'Blaze #1';
-  starterHero.icon = 'bomb';
+  starterHero.icon = 'flame';
+  starterHero.templateId = 'blaze';
+  starterHero.family = 'ember-clan';
 
   return {
     bomberCoins: 2000,

--- a/src/game/summoning.ts
+++ b/src/game/summoning.ts
@@ -1,5 +1,5 @@
-import { BESTIARY_BOMBERS } from '@/data/bestiary';
-import { Hero, Rarity, RARITY_CONFIG, HERO_NAMES, HERO_ICON_KEYS, Skill, HERO_VISUALS, HeroFamilyId } from './types';
+import { Hero, Rarity, RARITY_CONFIG, Skill } from './types';
+import { HERO_POOL } from './heroPool';
 
 let heroIdCounter = Date.now();
 
@@ -58,24 +58,6 @@ const SKILL_POOL_BY_RARITY: Record<Rarity, string[]> = {
   ],
 };
 
-export const CANONICAL_HERO_POOL_BY_RARITY: Record<Rarity, { id: string; name: string; iconKey: string }[]> = {
-  common: [],
-  rare: [],
-  'super-rare': [],
-  epic: [],
-  legend: [],
-  'super-legend': [],
-};
-
-for (const bomber of BESTIARY_BOMBERS) {
-  if (!bomber.rarity) continue;
-  CANONICAL_HERO_POOL_BY_RARITY[bomber.rarity].push({
-    id: bomber.id,
-    name: bomber.name,
-    iconKey: bomber.assets.iconKey ?? HERO_ICON_KEYS[HERO_NAMES.indexOf(bomber.name) % HERO_ICON_KEYS.length] ?? HERO_ICON_KEYS[0],
-  });
-}
-
 export function rollRarity(pityCounters: { rare: number; superRare: number; epic: number; legend: number }): Rarity {
   // Check pity
   if (pityCounters.legend >= 200) return 'legend';
@@ -102,16 +84,18 @@ function fisherYates<T>(arr: T[]): T[] {
   return arr;
 }
 
+export function generateSkillsForRarity(rarity: Rarity): Skill[] {
+  const config = RARITY_CONFIG[rarity];
+  const skillPool = SKILL_POOL_BY_RARITY[rarity];
+  const shuffled = fisherYates([...skillPool]);
+  return shuffled.slice(0, config.skills).map(k => ALL_SKILLS[k]);
+}
+
 export function generateHero(rarity: Rarity): Hero {
   const config = RARITY_CONFIG[rarity];
-  const canonicalPool = CANONICAL_HERO_POOL_BY_RARITY[rarity];
-  const pickedCanonicalHero = canonicalPool.length > 0
-    ? canonicalPool[Math.floor(Math.random() * canonicalPool.length)]
-    : null;
 
-  const name = pickedCanonicalHero?.name ?? HERO_NAMES[Math.floor(Math.random() * HERO_NAMES.length)];
-  const icon = pickedCanonicalHero?.iconKey ?? HERO_ICON_KEYS[Math.floor(Math.random() * HERO_ICON_KEYS.length)];
-  const family = (HERO_VISUALS[name.toLowerCase()]?.family || undefined) as HeroFamilyId | undefined;
+  // Tirage d'un template depuis le pool fixe (cohérence nom/icône/clan)
+  const template = HERO_POOL[Math.floor(Math.random() * HERO_POOL.length)];
 
   // Random variance ±10%
   const vary = (base: number) => Math.max(1, Math.round(base * (STAT_VARIANCE_MIN + Math.random() * STAT_VARIANCE_RANGE)));
@@ -125,17 +109,14 @@ export function generateHero(rarity: Rarity): Hero {
     lck: vary(config.baseStats.lck),
   };
 
-  // Pick skills
-  const skillPool = SKILL_POOL_BY_RARITY[rarity];
-  const numSkills = config.skills;
-  const shuffled = fisherYates([...skillPool]);
-  const skills = shuffled.slice(0, numSkills).map(k => ALL_SKILLS[k]);
+  const skills = generateSkillsForRarity(rarity);
 
   const id = `hero_${heroIdCounter++}`;
 
   return {
     id,
-    name: `${name} #${id.split('_')[1]}`,
+    templateId: template.templateId,
+    name: `${template.name} #${id.split('_')[1]}`,
     rarity,
     level: 1,
     xp: 0,
@@ -152,8 +133,8 @@ export function generateHero(rarity: Rarity): Hero {
     state: 'idle',
     bombCooldown: 0,
     stuckTimer: 0,
-    icon,
-    family,
+    icon: template.icon,
+    family: template.family,
     progressionStats: {
       chestsOpened: 0,
       totalDamageDealt: 0,

--- a/src/game/types.ts
+++ b/src/game/types.ts
@@ -36,6 +36,7 @@ export interface HeroProgressionStats {
 
 export interface Hero {
   id: string;
+  templateId?: string; // Référence au template du pool (heroPool.ts)
   name: string;
   rarity: Rarity;
   level: number;

--- a/src/game/upgradeSystem.ts
+++ b/src/game/upgradeSystem.ts
@@ -1,5 +1,5 @@
 import { Hero, HeroStats, Rarity, Skill, RARITY_CONFIG, MAX_LEVEL_BY_RARITY } from './types';
-import { generateHero } from './summoning';
+import { generateSkillsForRarity } from './summoning';
 
 /** XP required per level (level 1 requires 0 XP, level 2 requires XP_FOR_LEVEL[1], etc.) */
 const XP_FOR_LEVEL: Record<number, number> = {
@@ -477,16 +477,14 @@ export function upgradeHeroRarity(hero: Hero, to: Rarity): Hero {
   const fromConfig = RARITY_CONFIG[hero.rarity];
   const newLevel = fromConfig.maxLevel;
   const newStats = getStatsAtLevel(to, newLevel, hero.stars);
-  // On génère un héros temporaire de la rareté cible pour récupérer ses skills
-  const tempHero = generateHero(to);
   return {
-    ...hero,                       // conserve id, name, family, icon, progressionStats…
+    ...hero,                       // conserve id, templateId, name, family, icon, progressionStats…
     rarity: to,
     level: newLevel,
     xp: 0,
     stars: 0,
     stats: newStats,
-    skills: tempHero.skills,
+    skills: generateSkillsForRarity(to),
     maxStamina: newStats.sta,
     currentStamina: newStats.sta,
   };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2447,7 +2447,8 @@ const Index = () => {
                                   player.heroes.filter(h =>
                                     h.rarity === recipe.from &&
                                     h.level >= RARITY_CONFIG[recipe.from].maxLevel &&
-                                    !alreadyIds.has(h.id)
+                                    !alreadyIds.has(h.id) &&
+                                    !h.isLocked
                                   )
                                 );
                                 handleSlotClick(slotIdx);

--- a/src/test/rosterValidation.test.ts
+++ b/src/test/rosterValidation.test.ts
@@ -5,9 +5,9 @@
  * entre HERO_NAMES, HERO_FAMILY_MAP, HERO_VISUALS et BESTIARY_BOMBERS.
  */
 import { describe, it, expect } from 'vitest';
-import { HERO_NAMES, HERO_FAMILY_MAP, HERO_VISUALS, HERO_FAMILIES } from '../game/types';
+import { HERO_NAMES, HERO_FAMILY_MAP, HERO_VISUALS, HERO_FAMILIES, HERO_ICON_KEYS } from '../game/types';
 import { BESTIARY_BOMBERS } from '../data/bestiary';
-import { CANONICAL_HERO_POOL_BY_RARITY } from '../game/summoning';
+import { HERO_POOL } from '../game/heroPool';
 
 const TOTAL_HEROES = 36;
 const HEROES_PER_CLAN = 6;
@@ -142,37 +142,39 @@ describe('BESTIARY_BOMBERS', () => {
   });
 });
 
-// ─── 5. CANONICAL_HERO_POOL_BY_RARITY ─────────────────────────────────────────
+// ─── 5. HERO_POOL ──────────────────────────────────────────────────────────────
 
-describe('CANONICAL_HERO_POOL_BY_RARITY', () => {
-  it(`couvre les ${TOTAL_HEROES} héros (chaque héros dans au moins 1 rareté)`, () => {
-    const coveredIds = new Set<string>();
-    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
-      for (const hero of pool) {
-        coveredIds.add(hero.id);
-      }
-    }
-    expect(coveredIds.size).toBe(TOTAL_HEROES);
+describe('HERO_POOL', () => {
+  it(`contient exactement ${TOTAL_HEROES} templates`, () => {
+    expect(HERO_POOL).toHaveLength(TOTAL_HEROES);
   });
 
-  it("ne contient pas de doublons dans une même rareté", () => {
-    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
-      const ids = pool.map(h => h.id);
-      const unique = new Set(ids);
-      expect(unique.size).toBe(ids.length);
+  it("ne contient pas de doublons de templateId", () => {
+    const ids = HERO_POOL.map(t => t.templateId);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('chaque template a un templateId, un name, une icône et une family valides', () => {
+    const validIcons = new Set(HERO_ICON_KEYS);
+    for (const template of HERO_POOL) {
+      expect(typeof template.templateId).toBe('string');
+      expect(template.templateId.length).toBeGreaterThan(0);
+      expect(typeof template.name).toBe('string');
+      expect(template.name.length).toBeGreaterThan(0);
+      expect(validIcons.has(template.icon)).toBe(true);
+      expect(typeof template.family).toBe('string');
+      expect(template.family.length).toBeGreaterThan(0);
     }
   });
 
-  it('chaque héros du pool a un id, un name et un iconKey valides', () => {
-    for (const pool of Object.values(CANONICAL_HERO_POOL_BY_RARITY)) {
-      for (const hero of pool) {
-        expect(typeof hero.id).toBe('string');
-        expect(hero.id.length).toBeGreaterThan(0);
-        expect(typeof hero.name).toBe('string');
-        expect(hero.name.length).toBeGreaterThan(0);
-        expect(typeof hero.iconKey).toBe('string');
-        expect(hero.iconKey.length).toBeGreaterThan(0);
-      }
+  it('chaque clan a exactement 6 templates', () => {
+    const countPerFamily: Record<string, number> = {};
+    for (const t of HERO_POOL) {
+      countPerFamily[t.family] = (countPerFamily[t.family] ?? 0) + 1;
+    }
+    for (const count of Object.values(countPerFamily)) {
+      expect(count).toBe(6);
     }
   });
 });

--- a/src/test/summoning.test.ts
+++ b/src/test/summoning.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { rollRarity, generateHero, summonHero } from '../game/summoning';
 import { RARITY_CONFIG } from '../game/types';
 import type { Rarity } from '../game/types';
+import { HERO_POOL } from '../game/heroPool';
 
 // Fixture de base pour les compteurs de pity
 const zeroPity = { rare: 0, superRare: 0, epic: 0, legend: 0 };
@@ -131,6 +132,37 @@ describe('generateHero', () => {
     const h1 = generateHero('common');
     const h2 = generateHero('common');
     expect(h1.id).not.toBe(h2.id);
+  });
+});
+
+// ─── generateHero — pool cohérent ─────────────────────────────────────────────
+
+describe('generateHero — pool cohérent', () => {
+  it('icône et family correspondent au template', () => {
+    for (let i = 0; i < 20; i++) {
+      const hero = generateHero('common');
+      const baseName = hero.name.split(' #')[0];
+      const template = HERO_POOL.find(t => t.name === baseName);
+      expect(template).toBeDefined();
+      expect(hero.icon).toBe(template!.icon);
+      expect(hero.family).toBe(template!.family);
+    }
+  });
+
+  it('templateId est défini et correspond au pool', () => {
+    const hero = generateHero('rare');
+    expect(typeof hero.templateId).toBe('string');
+    const template = HERO_POOL.find(t => t.templateId === hero.templateId);
+    expect(template).toBeDefined();
+  });
+
+  it('le nom de base est toujours dans le pool', () => {
+    const poolNames = new Set(HERO_POOL.map(t => t.name));
+    for (let i = 0; i < 10; i++) {
+      const hero = generateHero('super-rare');
+      const baseName = hero.name.split(' #')[0];
+      expect(poolNames.has(baseName)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
## Résumé

Refonte du système de génération et fusion des héros (issue #333).

## Changements

### Volet A — Pool de héros fixes
- Nouveau fichier \`src/game/heroPool.ts\` : 36 templates (6 clans × 6 persos) avec icône et clan cohérents
- \`generateHero()\` dans \`summoning.ts\` : toujours picker depuis \`HERO_POOL\` — plus de tirage aléatoire nom/icône découplés
- Nouveau champ \`templateId?: string\` sur l'interface \`Hero\`
- Nouvelle fonction exportée \`generateSkillsForRarity(rarity)\` extraite depuis \`generateHero()\`

### Volet B — Identité préservée à la fusion
- \`upgradeHeroRarity()\` dans \`upgradeSystem.ts\` : utilise \`generateSkillsForRarity()\` au lieu de \`generateHero()\` — le héros conserve son id, templateId, nom, icône, clan lors de la montée en rareté

### Fixes mineurs
- \`bestiary.ts\` : correction du mapping d'icônes défectueux (index modulo → lookup par HERO_POOL)
- \`saveSystem.ts\` : starter hero Blaze avec \`templateId\`, \`family\` et \`icon\` corrects (\`flame\` au lieu de \`bomb\`)
- \`Index.tsx\` : les héros verrouillés exclus des slots nourriture de fusion

### Tests
- \`rosterValidation.test.ts\` : migré de \`CANONICAL_HERO_POOL_BY_RARITY\` vers \`HERO_POOL\` (4 nouveaux tests)
- \`summoning.test.ts\` : 3 nouveaux tests de cohérence pool (icône, family, templateId)

## Test plan
- [x] \`npm run build\` — zéro erreur TypeScript (2240 modules)
- [x] \`npm test\` — 185/185 tests passent (12 fichiers)
- [x] Génération héros : nom/icône/clan toujours cohérents via HERO_POOL
- [x] Fusion : le héros principal conserve son identité après upgrade
- [x] Héros verrouillés non proposés comme nourriture

Closes #333

🤖 Generated with [Claude Code](https://claude.com/claude-code)