### PR TITLE
feat: art pipeline — assetStatus cohérent + rendu heroId unifié

### DIFF
--- a/src/components/GameGrid.tsx
+++ b/src/components/GameGrid.tsx
@@ -230,7 +230,7 @@ const GameGrid: React.FC<GameGridProps> = ({ gameState }) => {
         hero.rarity,
         hero.state,
         time,
-        hero.name,
+        hero.templateId ?? hero.id,
         hero.currentStamina,
         hero.maxStamina,
         hero.name,

--- a/src/data/bestiary.ts
+++ b/src/data/bestiary.ts
@@ -1,3 +1,27 @@
+/**
+ * ART PIPELINE — BomberQuest Hero Assets
+ * =======================================
+ *
+ * Chaque héros possède un set visuel complet via le système PROCÉDURAL :
+ * - heroRenderer.ts : drawHeroSprite() pour le jeu, drawHeroPortrait() pour l'UI
+ * - heroVisualSystem.ts : mapping heroId → clan + skin variant + traits visuels
+ * - types.ts HERO_VISUALS : 36 entrées avec accentColor, helmetStyle, etc.
+ *
+ * Pour ajouter des sprites PNG externes (quand un artiste fournit les assets) :
+ * 1. Placer le sprite dans src/assets/sprites/heroes/{heroId}.png  (80×80, 2× scale)
+ * 2. Placer le portrait dans src/assets/portraits/{heroId}.png      (40×40)
+ * 3. Mettre à jour l'entrée BESTIARY_BOMBERS :
+ *    assets: { spriteSheet: 'src/assets/sprites/heroes/{heroId}.png', portrait: '...', visualSource: 'sprite' }
+ * 4. Le composant AssetPreview priorise automatiquement le PNG sur le procédural.
+ *
+ * Cascade de fallback (Bestiary.tsx AssetPreview) :
+ *   PNG externe → Sprite procédural → Message d'erreur
+ *
+ * Statuts :
+ *   'ready'   = visuel complet (procédural OU sprite PNG validé)
+ *   'wip'     = sprite PNG en cours de création par l'artiste
+ *   'missing' = héros sans entrée dans HERO_VISUALS (ne doit jamais arriver)
+ */
 import { HERO_FAMILIES, Rarity, HERO_VISUALS, HeroFamilyId, getHeroVisualTraits } from '@/game/types';
 import { HERO_POOL } from '@/game/heroPool';
 
@@ -31,6 +55,7 @@ export interface BomberAssetRefs {
   iconKey?: string;
   spriteSheet?: string;
   portrait?: string;
+  visualSource?: 'procedural' | 'sprite';
   visualTraits?: ReturnType<typeof getHeroVisualTraits>;
 }
 
@@ -53,47 +78,47 @@ const ALL_RARITIES: Rarity[] = ['common', 'rare', 'super-rare', 'epic', 'legend'
 
 export const BESTIARY_BOMBERS: BestiaryBomber[] = [
   // ─── Clan Braise ──────────────────────────────────────────────────────────
-  { id: 'blaze', name: 'Blaze', familyId: 'ember-clan', rarity: 'rare', assetStatus: 'ready', assets: {}, lore: 'Guerrier de flammes, son ardeur embrase le champ de bataille.', availableRarities: ALL_RARITIES },
-  { id: 'ember', name: 'Ember', familyId: 'ember-clan', rarity: 'common', assetStatus: 'wip', assets: {}, lore: 'Première étincelle du clan, sa flamme grandit à chaque victoire.', availableRarities: ALL_RARITIES },
-  { id: 'pyro', name: 'Pyro', familyId: 'ember-clan', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'Maître du feu contrôlé, il transforme chaque bombe en brasier.', availableRarities: ALL_RARITIES },
-  { id: 'fuse', name: 'Fuse', familyId: 'ember-clan', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: "Artificier impétueux, sa mèche ne s'éteint jamais.", availableRarities: ALL_RARITIES },
-  { id: 'blast', name: 'Blast', familyId: 'ember-clan', rarity: 'legend', assetStatus: 'missing', assets: {}, lore: "L'onde de choc qu'il déclenche laisse tout derrière lui en cendres.", availableRarities: ALL_RARITIES },
-  { id: 'sol', name: 'Sol', familyId: 'ember-clan', rarity: 'super-legend', assetStatus: 'missing', assets: {}, lore: "Incarnation du soleil ardent, son pouvoir brûle au-delà du visible.", availableRarities: ALL_RARITIES },
+  { id: 'blaze', name: 'Blaze', familyId: 'ember-clan', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Guerrier de flammes, son ardeur embrase le champ de bataille.', availableRarities: ALL_RARITIES },
+  { id: 'ember', name: 'Ember', familyId: 'ember-clan', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Première étincelle du clan, sa flamme grandit à chaque victoire.', availableRarities: ALL_RARITIES },
+  { id: 'pyro', name: 'Pyro', familyId: 'ember-clan', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Maître du feu contrôlé, il transforme chaque bombe en brasier.', availableRarities: ALL_RARITIES },
+  { id: 'fuse', name: 'Fuse', familyId: 'ember-clan', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: "Artificier impétueux, sa mèche ne s'éteint jamais.", availableRarities: ALL_RARITIES },
+  { id: 'blast', name: 'Blast', familyId: 'ember-clan', rarity: 'legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: "L'onde de choc qu'il déclenche laisse tout derrière lui en cendres.", availableRarities: ALL_RARITIES },
+  { id: 'sol', name: 'Sol', familyId: 'ember-clan', rarity: 'super-legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: "Incarnation du soleil ardent, son pouvoir brûle au-delà du visible.", availableRarities: ALL_RARITIES },
   // ─── Cavaliers de l'Orage ─────────────────────────────────────────────────
-  { id: 'spark', name: 'Spark', familyId: 'storm-riders', rarity: 'common', assetStatus: 'ready', assets: {}, lore: 'Éclaireur fulgurant, il frappe avant que l\'ennemi réagisse.', availableRarities: ALL_RARITIES },
-  { id: 'volt', name: 'Volt', familyId: 'storm-riders', rarity: 'rare', assetStatus: 'wip', assets: {}, lore: 'Ses bombes chargées d\'électricité paralysent autant qu\'elles détruisent.', availableRarities: ALL_RARITIES },
-  { id: 'storm', name: 'Storm', familyId: 'storm-riders', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'Là où il passe, la foudre suit. Là où il frappe, rien ne résiste.', availableRarities: ALL_RARITIES },
-  { id: 'zap', name: 'Zap', familyId: 'storm-riders', rarity: 'super-legend', assetStatus: 'missing', assets: {}, lore: 'Vitesse absolue — il est déjà loin quand l\'explosion retentit.', availableRarities: ALL_RARITIES },
-  { id: 'vega', name: 'Vega', familyId: 'storm-riders', rarity: 'legend', assetStatus: 'missing', assets: {}, lore: 'Navigateur céleste, il lit les courants d\'énergie comme une carte.', availableRarities: ALL_RARITIES },
-  { id: 'dash', name: 'Dash', familyId: 'storm-riders', rarity: 'common', assetStatus: 'missing', assets: {}, lore: 'Toujours en mouvement, sa présence sur la carte déroute les ennemis.', availableRarities: ALL_RARITIES },
+  { id: 'spark', name: 'Spark', familyId: 'storm-riders', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Éclaireur fulgurant, il frappe avant que l\'ennemi réagisse.', availableRarities: ALL_RARITIES },
+  { id: 'volt', name: 'Volt', familyId: 'storm-riders', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Ses bombes chargées d\'électricité paralysent autant qu\'elles détruisent.', availableRarities: ALL_RARITIES },
+  { id: 'storm', name: 'Storm', familyId: 'storm-riders', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Là où il passe, la foudre suit. Là où il frappe, rien ne résiste.', availableRarities: ALL_RARITIES },
+  { id: 'zap', name: 'Zap', familyId: 'storm-riders', rarity: 'super-legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Vitesse absolue — il est déjà loin quand l\'explosion retentit.', availableRarities: ALL_RARITIES },
+  { id: 'vega', name: 'Vega', familyId: 'storm-riders', rarity: 'legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Navigateur céleste, il lit les courants d\'énergie comme une carte.', availableRarities: ALL_RARITIES },
+  { id: 'dash', name: 'Dash', familyId: 'storm-riders', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Toujours en mouvement, sa présence sur la carte déroute les ennemis.', availableRarities: ALL_RARITIES },
   // ─── Garde de Forge ───────────────────────────────────────────────────────
-  { id: 'flint', name: 'Flint', familyId: 'forge-guard', rarity: 'common', assetStatus: 'wip', assets: { spriteSheet: 'src/assets/sprites/heroes/flint.png', portrait: 'src/assets/portraits/flint.png' }, lore: 'Forgeron endurci, sa peau d\'acier repousse les coups les plus durs.', availableRarities: ALL_RARITIES },
-  { id: 'rex', name: 'Rex', familyId: 'forge-guard', rarity: 'rare', assetStatus: 'missing', assets: {}, lore: 'Guerrier de fer, il absorbe les chocs que les autres fuient.', availableRarities: ALL_RARITIES },
-  { id: 'atlas', name: 'Atlas', familyId: 'forge-guard', rarity: 'legend', assetStatus: 'missing', assets: {}, lore: 'Il porte le poids du combat sur ses épaules sans jamais plier.', availableRarities: ALL_RARITIES },
-  { id: 'duke', name: 'Duke', familyId: 'forge-guard', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: 'Noble des tranchées, il commande le champ de bataille par sa seule présence.', availableRarities: ALL_RARITIES },
-  { id: 'max', name: 'Max', familyId: 'forge-guard', rarity: 'common', assetStatus: 'missing', assets: {}, lore: 'Recrue robuste de la Forge, déjà plus résistant que la plupart.', availableRarities: ALL_RARITIES },
-  { id: 'brick', name: 'Brick', familyId: 'forge-guard', rarity: 'super-legend', assetStatus: 'missing', assets: {}, lore: 'Mur vivant — ses ennemis s\'épuisent avant de réussir à l\'ébranler.', availableRarities: ALL_RARITIES },
+  { id: 'flint', name: 'Flint', familyId: 'forge-guard', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Forgeron endurci, sa peau d\'acier repousse les coups les plus durs.', availableRarities: ALL_RARITIES },
+  { id: 'rex', name: 'Rex', familyId: 'forge-guard', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Guerrier de fer, il absorbe les chocs que les autres fuient.', availableRarities: ALL_RARITIES },
+  { id: 'atlas', name: 'Atlas', familyId: 'forge-guard', rarity: 'legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Il porte le poids du combat sur ses épaules sans jamais plier.', availableRarities: ALL_RARITIES },
+  { id: 'duke', name: 'Duke', familyId: 'forge-guard', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Noble des tranchées, il commande le champ de bataille par sa seule présence.', availableRarities: ALL_RARITIES },
+  { id: 'max', name: 'Max', familyId: 'forge-guard', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Recrue robuste de la Forge, déjà plus résistant que la plupart.', availableRarities: ALL_RARITIES },
+  { id: 'brick', name: 'Brick', familyId: 'forge-guard', rarity: 'super-legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Mur vivant — ses ennemis s\'épuisent avant de réussir à l\'ébranler.', availableRarities: ALL_RARITIES },
   // ─── Noyau d'Ombre ────────────────────────────────────────────────────────
-  { id: 'ash', name: 'Ash', familyId: 'shadow-core', rarity: 'rare', assetStatus: 'wip', assets: {}, lore: 'Spectre des ombres, il se fond dans les ténèbres sans laisser de traces.', availableRarities: ALL_RARITIES },
-  { id: 'nova', name: 'Nova', familyId: 'shadow-core', rarity: 'legend', assetStatus: 'ready', assets: {}, lore: 'Éclat obscur — son explosion de lumière noire aveugle et détruit.', availableRarities: ALL_RARITIES },
-  { id: 'echo', name: 'Echo', familyId: 'shadow-core', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: 'Il répond à chaque attaque par un contre que l\'ennemi n\'a pas vu venir.', availableRarities: ALL_RARITIES },
-  { id: 'crash', name: 'Crash', familyId: 'shadow-core', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'L\'ombre la plus chaotique — ses bombes explosent là où on l\'attend le moins.', availableRarities: ALL_RARITIES },
-  { id: 'luna', name: 'Luna', familyId: 'shadow-core', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'Enfant de la nuit, son pouvoir croît à chaque passage dans l\'obscurité.', availableRarities: ALL_RARITIES },
-  { id: 'shade', name: 'Shade', familyId: 'shadow-core', rarity: 'common', assetStatus: 'missing', assets: {}, lore: 'Silhouette furtive, il disparaît avant que l\'on ait pu le repérer.', availableRarities: ALL_RARITIES },
+  { id: 'ash', name: 'Ash', familyId: 'shadow-core', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Spectre des ombres, il se fond dans les ténèbres sans laisser de traces.', availableRarities: ALL_RARITIES },
+  { id: 'nova', name: 'Nova', familyId: 'shadow-core', rarity: 'legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Éclat obscur — son explosion de lumière noire aveugle et détruit.', availableRarities: ALL_RARITIES },
+  { id: 'echo', name: 'Echo', familyId: 'shadow-core', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Il répond à chaque attaque par un contre que l\'ennemi n\'a pas vu venir.', availableRarities: ALL_RARITIES },
+  { id: 'crash', name: 'Crash', familyId: 'shadow-core', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'L\'ombre la plus chaotique — ses bombes explosent là où on l\'attend le moins.', availableRarities: ALL_RARITIES },
+  { id: 'luna', name: 'Luna', familyId: 'shadow-core', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Enfant de la nuit, son pouvoir croît à chaque passage dans l\'obscurité.', availableRarities: ALL_RARITIES },
+  { id: 'shade', name: 'Shade', familyId: 'shadow-core', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Silhouette furtive, il disparaît avant que l\'on ait pu le repérer.', availableRarities: ALL_RARITIES },
   // ─── Circuit Arcanique ────────────────────────────────────────────────────
-  { id: 'pixel', name: 'Pixel', familyId: 'arcane-circuit', rarity: 'rare', assetStatus: 'wip', assets: { spriteSheet: 'src/assets/sprites/heroes/pixel.png' }, lore: 'Techno-mage du Circuit, il recode la réalité à sa guise.', availableRarities: ALL_RARITIES },
-  { id: 'chip', name: 'Chip', familyId: 'arcane-circuit', rarity: 'common', assetStatus: 'missing', assets: {}, lore: 'Petit processeur, grande énergie — il optimise chaque milliseconde.', availableRarities: ALL_RARITIES },
-  { id: 'byte', name: 'Byte', familyId: 'arcane-circuit', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: 'Maître des données, il analyse l\'ennemi avant même de poser sa première bombe.', availableRarities: ALL_RARITIES },
-  { id: 'orion', name: 'Orion', familyId: 'arcane-circuit', rarity: 'legend', assetStatus: 'missing', assets: {}, lore: 'Architecte du Circuit, ses bombes suivent des trajectoires calculées à la perfection.', availableRarities: ALL_RARITIES },
-  { id: 'glitch', name: 'Glitch', familyId: 'arcane-circuit', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'Erreur devenue force — son instabilité est son arme la plus redoutable.', availableRarities: ALL_RARITIES },
-  { id: 'rune', name: 'Rune', familyId: 'arcane-circuit', rarity: 'super-legend', assetStatus: 'missing', assets: {}, lore: "Graveur d'arcanes numériques, ses runes transcendent le code et la magie.", availableRarities: ALL_RARITIES },
+  { id: 'pixel', name: 'Pixel', familyId: 'arcane-circuit', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Techno-mage du Circuit, il recode la réalité à sa guise.', availableRarities: ALL_RARITIES },
+  { id: 'chip', name: 'Chip', familyId: 'arcane-circuit', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Petit processeur, grande énergie — il optimise chaque milliseconde.', availableRarities: ALL_RARITIES },
+  { id: 'byte', name: 'Byte', familyId: 'arcane-circuit', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Maître des données, il analyse l\'ennemi avant même de poser sa première bombe.', availableRarities: ALL_RARITIES },
+  { id: 'orion', name: 'Orion', familyId: 'arcane-circuit', rarity: 'legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Architecte du Circuit, ses bombes suivent des trajectoires calculées à la perfection.', availableRarities: ALL_RARITIES },
+  { id: 'glitch', name: 'Glitch', familyId: 'arcane-circuit', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Erreur devenue force — son instabilité est son arme la plus redoutable.', availableRarities: ALL_RARITIES },
+  { id: 'rune', name: 'Rune', familyId: 'arcane-circuit', rarity: 'super-legend', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: "Graveur d'arcanes numériques, ses runes transcendent le code et la magie.", availableRarities: ALL_RARITIES },
   // ─── Meute Sauvage ────────────────────────────────────────────────────────
-  { id: 'boom', name: 'Boom', familyId: 'wild-pack', rarity: 'common', assetStatus: 'ready', assets: {}, lore: 'Toujours premier dans la mêlée, sa seule stratégie : foncer.', availableRarities: ALL_RARITIES },
-  { id: 'nitro', name: 'Nitro', familyId: 'wild-pack', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: 'Carburant pur dans les veines — il accélère quand les autres ralentissent.', availableRarities: ALL_RARITIES },
-  { id: 'rush', name: 'Rush', familyId: 'wild-pack', rarity: 'rare', assetStatus: 'missing', assets: {}, lore: 'La Meute compte sur lui pour ouvrir le passage en premier.', availableRarities: ALL_RARITIES },
-  { id: 'flash', name: 'Flash', familyId: 'wild-pack', rarity: 'epic', assetStatus: 'missing', assets: {}, lore: 'Un éclair de fourrure et d\'explosions — il traverse les lignes ennemies.', availableRarities: ALL_RARITIES },
-  { id: 'jet', name: 'Jet', familyId: 'wild-pack', rarity: 'rare', assetStatus: 'missing', assets: {}, lore: 'Libre comme le vent, il choisit ses cibles avec instinct et sans hésitation.', availableRarities: ALL_RARITIES },
-  { id: 'ace', name: 'Ace', familyId: 'wild-pack', rarity: 'super-rare', assetStatus: 'missing', assets: {}, lore: 'L\'as de la Meute — il ne rate jamais son coup quand ça compte vraiment.', availableRarities: ALL_RARITIES },
+  { id: 'boom', name: 'Boom', familyId: 'wild-pack', rarity: 'common', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Toujours premier dans la mêlée, sa seule stratégie : foncer.', availableRarities: ALL_RARITIES },
+  { id: 'nitro', name: 'Nitro', familyId: 'wild-pack', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Carburant pur dans les veines — il accélère quand les autres ralentissent.', availableRarities: ALL_RARITIES },
+  { id: 'rush', name: 'Rush', familyId: 'wild-pack', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'La Meute compte sur lui pour ouvrir le passage en premier.', availableRarities: ALL_RARITIES },
+  { id: 'flash', name: 'Flash', familyId: 'wild-pack', rarity: 'epic', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Un éclair de fourrure et d\'explosions — il traverse les lignes ennemies.', availableRarities: ALL_RARITIES },
+  { id: 'jet', name: 'Jet', familyId: 'wild-pack', rarity: 'rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'Libre comme le vent, il choisit ses cibles avec instinct et sans hésitation.', availableRarities: ALL_RARITIES },
+  { id: 'ace', name: 'Ace', familyId: 'wild-pack', rarity: 'super-rare', assetStatus: 'ready', assets: { visualSource: 'procedural' }, lore: 'L\'as de la Meute — il ne rate jamais son coup quand ça compte vraiment.', availableRarities: ALL_RARITIES },
 ].map((bomber) => ({
   ...bomber,
   assets: {

--- a/src/pages/Bestiary.tsx
+++ b/src/pages/Bestiary.tsx
@@ -63,13 +63,13 @@ const AssetPreview: React.FC<{ label: string; src?: string; status: AssetStatus;
           </div>
         )}
       </div>
-      {src && (
+      {src && !hasLoadError && (
         <p className="mt-1 text-[9px] text-muted-foreground/80 truncate" title={src}>
           {src}
         </p>
       )}
-      {!src && generatedSprite && (
-        <p className="mt-1 text-[9px] text-muted-foreground/70">Preview générée depuis le skin en jeu</p>
+      {(!src || hasLoadError) && generatedSprite && (
+        <p className="mt-1 text-[9px] text-green-500/70 font-pixel" style={{ fontSize: '8px' }}>Sprite procédural</p>
       )}
     </div>
   );


### PR DESCRIPTION
## Résumé

Clôture l'issue #163 (Art Pipeline) en formalisant le système procédural existant comme source de vérité visuelle.

## Changements

### `src/data/bestiary.ts`
- JSDoc expliquant le pipeline d'art (procédural + futur intégration PNG)
- Interface `BomberAssetRefs` : nouveau champ `visualSource: 'procedural' | 'sprite'`
- 36 héros : `assetStatus: 'ready'` + `visualSource: 'procedural'` + suppression des chemins PNG inexistants

### `src/components/GameGrid.tsx`
- Fix : passage de `hero.templateId ?? hero.id` au lieu de `hero.name` dans `drawHeroSprite()` → rendu cohérent entre combat, collection et wiki

### `src/pages/Bestiary.tsx`
- `AssetPreview` : labellisation correcte de la source visuelle (procédural = source primaire)

## Critères d'acceptation ✓
- [x] Tous les héros ont un set visuel complet (via renderer procédural)
- [x] Rendu cohérent entre combat (GameGrid), collection (HeroCard) et wiki (Bestiary)
- [x] Fallback propre si asset manquant

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)