### PR TITLE
feat: marketplace — vente de héros entre joueurs

### DIFF
--- a/src/components/MainNav.tsx
+++ b/src/components/MainNav.tsx
@@ -1,9 +1,9 @@
 import { motion } from 'framer-motion';
-import { Sparkles, Users, Swords, Trophy, Flame } from 'lucide-react';
+import { Sparkles, Users, Swords, Trophy, Flame, Store } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface MainNavProps {
-  page: number; // 0-4
+  page: number; // 0-5
   onNavigate: (page: number) => void;
 }
 
@@ -13,6 +13,7 @@ const PAGES = [
   { icon: Swords, label: 'Combat' },
   { icon: Trophy, label: 'Progression' },
   { icon: Flame, label: 'Forge' },
+  { icon: Store, label: 'Marché' },
 ];
 
 export function MainNav({ page, onNavigate }: MainNavProps) {

--- a/src/components/marketplace/BuyConfirmModal.tsx
+++ b/src/components/marketplace/BuyConfirmModal.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { Coins } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import HeroAvatar from '@/components/HeroAvatar';
+import { MarketplaceListing, MarketplaceHeroSnapshot } from '@/hooks/useMarketplace';
+import { RARITY_CONFIG, Rarity } from '@/game/types';
+import { cn } from '@/lib/utils';
+
+interface BuyConfirmModalProps {
+  listing: MarketplaceListing | null;
+  playerCoins: number;
+  isLoading: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export default function BuyConfirmModal({
+  listing,
+  playerCoins,
+  isLoading,
+  onConfirm,
+  onClose,
+}: BuyConfirmModalProps) {
+  if (!listing) return null;
+
+  const hero = listing.hero_snapshot as MarketplaceHeroSnapshot;
+  const afterBalance = playerCoins - listing.price;
+  const canAfford = afterBalance >= 0;
+  const rarityConfig = RARITY_CONFIG[hero.rarity as Rarity];
+
+  return (
+    <Dialog open={!!listing} onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent className="pixel-border bg-card max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-pixel text-[10px]">Confirmer l'achat</DialogTitle>
+        </DialogHeader>
+
+        {/* Hero preview */}
+        <div className={cn('flex items-center gap-3 p-3 pixel-border', `rarity-${hero.rarity}`)}>
+          <HeroAvatar
+            heroName={hero.name.toLowerCase().split(' #')[0]}
+            rarity={hero.rarity as Rarity}
+            size={56}
+            className="shrink-0"
+          />
+          <div>
+            <div className="font-pixel text-[9px]">{hero.name}</div>
+            <div
+              className="font-pixel text-[7px] inline-block px-1 rounded mt-0.5"
+              style={{ background: `hsl(var(--game-rarity-${hero.rarity}))`, color: '#000' }}
+            >
+              {rarityConfig?.label ?? hero.rarity}
+            </div>
+            <div className="font-pixel text-[7px] text-muted-foreground mt-0.5">
+              Niv. {hero.level} · {hero.stars}★
+            </div>
+          </div>
+        </div>
+
+        {/* Résumé financier */}
+        <div className="space-y-1.5 font-pixel text-[8px]">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Prix</span>
+            <span className="flex items-center gap-1 text-game-gold">
+              <Coins size={11} /> {listing.price.toLocaleString()}
+            </span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Votre solde</span>
+            <span className="flex items-center gap-1">
+              <Coins size={11} /> {playerCoins.toLocaleString()}
+            </span>
+          </div>
+          <div className={cn('flex justify-between border-t border-border pt-1', canAfford ? 'text-green-400' : 'text-destructive')}>
+            <span>Solde après achat</span>
+            <span className="flex items-center gap-1">
+              <Coins size={11} /> {afterBalance.toLocaleString()}
+            </span>
+          </div>
+        </div>
+
+        {!canAfford && (
+          <p className="font-pixel text-[7px] text-destructive text-center">
+            Fonds insuffisants.
+          </p>
+        )}
+
+        <DialogFooter className="gap-2">
+          <button
+            onClick={onClose}
+            className="pixel-btn pixel-btn-secondary font-pixel text-[7px] px-3 py-2"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={!canAfford || isLoading}
+            className={cn(
+              'pixel-btn font-pixel text-[7px] px-3 py-2',
+              (!canAfford || isLoading) && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            {isLoading ? '...' : 'Confirmer'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/marketplace/CreateListingModal.tsx
+++ b/src/components/marketplace/CreateListingModal.tsx
@@ -1,0 +1,154 @@
+import React, { useState } from 'react';
+import { Coins } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import HeroAvatar from '@/components/HeroAvatar';
+import { Hero, RARITY_CONFIG, Rarity } from '@/game/types';
+import { cn } from '@/lib/utils';
+
+const SELLABLE_RARITIES: Rarity[] = ['epic', 'legend', 'super-legend'];
+
+interface CreateListingModalProps {
+  open: boolean;
+  heroes: Hero[];
+  isLoading: boolean;
+  onConfirm: (heroId: string, price: number) => void;
+  onClose: () => void;
+}
+
+export default function CreateListingModal({
+  open,
+  heroes,
+  isLoading,
+  onConfirm,
+  onClose,
+}: CreateListingModalProps) {
+  const [selectedHeroId, setSelectedHeroId] = useState<string | null>(null);
+  const [price, setPrice] = useState<number>(1000);
+
+  const sellableHeroes = heroes.filter(
+    (h) => SELLABLE_RARITIES.includes(h.rarity as Rarity) && !h.isLocked,
+  );
+
+  const selectedHero = sellableHeroes.find((h) => h.id === selectedHeroId) ?? null;
+
+  const handleConfirm = () => {
+    if (!selectedHeroId || price < 100) return;
+    onConfirm(selectedHeroId, price);
+    setSelectedHeroId(null);
+    setPrice(1000);
+  };
+
+  const handleClose = () => {
+    setSelectedHeroId(null);
+    setPrice(1000);
+    onClose();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
+      <DialogContent className="pixel-border bg-card max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-pixel text-[10px]">Mettre un héros en vente</DialogTitle>
+        </DialogHeader>
+
+        {sellableHeroes.length === 0 ? (
+          <p className="font-pixel text-[8px] text-muted-foreground text-center py-4">
+            Aucun héros Epic, Legend ou Super-Legend non verrouillé disponible.
+          </p>
+        ) : (
+          <>
+            {/* Picker héros */}
+            <div className="max-h-48 overflow-y-auto space-y-1 pr-1">
+              {sellableHeroes.map((hero) => {
+                const isSelected = selectedHeroId === hero.id;
+                const rarityConfig = RARITY_CONFIG[hero.rarity as Rarity];
+                return (
+                  <button
+                    key={hero.id}
+                    onClick={() => setSelectedHeroId(hero.id)}
+                    className={cn(
+                      'w-full flex items-center gap-3 p-2 pixel-border text-left transition-all',
+                      `rarity-${hero.rarity}`,
+                      isSelected ? 'ring-2 ring-primary bg-primary/10' : 'bg-card/50 hover:bg-card',
+                    )}
+                  >
+                    <HeroAvatar
+                      heroName={hero.name.toLowerCase().split(' #')[0]}
+                      rarity={hero.rarity as Rarity}
+                      size={36}
+                      className="shrink-0"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="font-pixel text-[8px] truncate">{hero.name}</div>
+                      <div className="font-pixel text-[6px] text-muted-foreground">
+                        {rarityConfig?.label} · Niv. {hero.level} · {hero.stars}★
+                      </div>
+                    </div>
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* Preview héros sélectionné */}
+            {selectedHero && (
+              <div className={cn('flex items-center gap-3 p-2 pixel-border', `rarity-${selectedHero.rarity}`)}>
+                <HeroAvatar
+                  heroName={selectedHero.name.toLowerCase().split(' #')[0]}
+                  rarity={selectedHero.rarity as Rarity}
+                  size={48}
+                  animated
+                />
+                <div>
+                  <div className="font-pixel text-[9px]">{selectedHero.name}</div>
+                  <div className="font-pixel text-[7px] text-muted-foreground">
+                    Niv. {selectedHero.level} · {selectedHero.stars}★
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Prix */}
+            <div className="space-y-1">
+              <label className="font-pixel text-[8px] text-muted-foreground flex items-center gap-1">
+                <Coins size={11} /> Prix (100 – 999 999)
+              </label>
+              <input
+                type="number"
+                min={100}
+                max={999999}
+                value={price}
+                onChange={(e) => setPrice(Math.max(100, Math.min(999999, Number(e.target.value))))}
+                className="w-full pixel-border bg-background font-pixel text-[9px] px-3 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              />
+            </div>
+          </>
+        )}
+
+        <DialogFooter className="gap-2">
+          <button
+            onClick={handleClose}
+            className="pixel-btn pixel-btn-secondary font-pixel text-[7px] px-3 py-2"
+          >
+            Annuler
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!selectedHeroId || price < 100 || isLoading || sellableHeroes.length === 0}
+            className={cn(
+              'pixel-btn font-pixel text-[7px] px-3 py-2',
+              (!selectedHeroId || price < 100 || isLoading) && 'opacity-50 cursor-not-allowed',
+            )}
+          >
+            {isLoading ? '...' : 'Mettre en vente'}
+          </button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/marketplace/ListingCard.tsx
+++ b/src/components/marketplace/ListingCard.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Coins, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import HeroAvatar from '@/components/HeroAvatar';
+import { MarketplaceListing, MarketplaceHeroSnapshot } from '@/hooks/useMarketplace';
+import { RARITY_CONFIG, Rarity } from '@/game/types';
+
+interface ListingCardProps {
+  listing: MarketplaceListing;
+  currentUserId?: string;
+  playerCoins: number;
+  onBuy: (listing: MarketplaceListing) => void;
+  onCancel: (listing: MarketplaceListing) => void;
+}
+
+export default function ListingCard({
+  listing,
+  currentUserId,
+  playerCoins,
+  onBuy,
+  onCancel,
+}: ListingCardProps) {
+  const hero = listing.hero_snapshot as MarketplaceHeroSnapshot;
+  const isOwn = currentUserId === listing.seller_id;
+  const canAfford = playerCoins >= listing.price;
+  const rarityConfig = RARITY_CONFIG[hero.rarity as Rarity];
+
+  return (
+    <div
+      className={cn(
+        'pixel-border p-3 flex flex-col gap-2 bg-card/80 hover:bg-card transition-colors',
+        `rarity-${hero.rarity}`,
+      )}
+    >
+      {/* Avatar + infos héros */}
+      <div className="flex items-center gap-3">
+        <HeroAvatar
+          heroName={hero.name.toLowerCase().split(' #')[0]}
+          rarity={hero.rarity as Rarity}
+          size={48}
+          className="shrink-0"
+        />
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-1 flex-wrap">
+            <span className="font-pixel text-[8px] truncate">{hero.name}</span>
+            <span
+              className="font-pixel text-[6px] px-1 rounded"
+              style={{ background: `hsl(var(--game-rarity-${hero.rarity}))`, color: '#000' }}
+            >
+              {rarityConfig?.label ?? hero.rarity}
+            </span>
+          </div>
+          <div className="font-pixel text-[7px] text-muted-foreground">
+            Niv. {hero.level} · {hero.stars}★
+          </div>
+          {listing.status === 'active' && isOwn && (
+            <div className="font-pixel text-[6px] text-yellow-400">Votre annonce</div>
+          )}
+        </div>
+      </div>
+
+      {/* Prix */}
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1 font-pixel text-[8px] text-game-gold">
+          <Coins size={12} className="text-game-gold" />
+          {listing.price.toLocaleString()}
+        </div>
+
+        {listing.status === 'active' && (
+          isOwn ? (
+            <button
+              onClick={() => onCancel(listing)}
+              className="pixel-btn pixel-btn-secondary font-pixel text-[7px] flex items-center gap-1 px-2 py-1 min-h-0"
+            >
+              <X size={10} /> Annuler
+            </button>
+          ) : currentUserId ? (
+            <button
+              onClick={() => onBuy(listing)}
+              disabled={!canAfford}
+              className={cn(
+                'pixel-btn font-pixel text-[7px] px-2 py-1 min-h-0',
+                !canAfford && 'opacity-50 cursor-not-allowed',
+              )}
+            >
+              Acheter
+            </button>
+          ) : null
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/marketplace/MarketplacePage.tsx
+++ b/src/components/marketplace/MarketplacePage.tsx
@@ -1,0 +1,245 @@
+import React, { useState } from 'react';
+import { Store, Tag, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { cn } from '@/lib/utils';
+import { PlayerData, Rarity, RARITY_CONFIG } from '@/game/types';
+import {
+  useListings,
+  useMyListings,
+  useCreateListing,
+  useBuyHero,
+  useCancelListing,
+  MarketplaceListing,
+  MarketplaceFilters,
+} from '@/hooks/useMarketplace';
+import ListingCard from './ListingCard';
+import BuyConfirmModal from './BuyConfirmModal';
+import CreateListingModal from './CreateListingModal';
+
+type Tab = 'browse' | 'my';
+type User = { id: string } | null;
+
+const SELLABLE_RARITIES: Rarity[] = ['epic', 'legend', 'super-legend'];
+
+interface MarketplacePageProps {
+  player: PlayerData;
+  user: User;
+  onTransactionComplete: () => void;
+}
+
+export default function MarketplacePage({ player, user, onTransactionComplete }: MarketplacePageProps) {
+  const [tab, setTab] = useState<Tab>('browse');
+  const [filters, setFilters] = useState<MarketplaceFilters>({ sortBy: 'newest' });
+  const [buyTarget, setBuyTarget] = useState<MarketplaceListing | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
+
+  const { data: listings = [], isLoading: loadingListings, refetch: refetchListings } = useListings(filters);
+  const { data: myListings = [], isLoading: loadingMy, refetch: refetchMy } = useMyListings(user?.id);
+  const createListing = useCreateListing();
+  const buyHero = useBuyHero();
+  const cancelListing = useCancelListing();
+
+  const handleBuy = (listing: MarketplaceListing) => setBuyTarget(listing);
+
+  const handleConfirmBuy = async () => {
+    if (!buyTarget || !user) return;
+    try {
+      const result = await buyHero.mutateAsync({ listingId: buyTarget.id, buyerId: user.id });
+      toast.success(`Héros acheté ! (${result.price_paid?.toLocaleString()} coins dépensés)`);
+      setBuyTarget(null);
+      onTransactionComplete();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de l'achat.");
+    }
+  };
+
+  const handleCancel = async (listing: MarketplaceListing) => {
+    if (!user) return;
+    try {
+      await cancelListing.mutateAsync({ listingId: listing.id, sellerId: user.id });
+      toast.success('Annonce annulée. Héros retourné dans votre collection.');
+      onTransactionComplete();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : "Erreur lors de l'annulation.");
+    }
+  };
+
+  const handleCreateListing = async (heroId: string, price: number) => {
+    if (!user) return;
+    try {
+      await createListing.mutateAsync({ sellerId: user.id, heroId, price });
+      toast.success('Héros mis en vente avec succès !');
+      setCreateOpen(false);
+      onTransactionComplete();
+    } catch (err: unknown) {
+      toast.error(err instanceof Error ? err.message : 'Erreur lors de la mise en vente.');
+    }
+  };
+
+  if (!user) {
+    return (
+      <div className="p-4 max-w-2xl mx-auto flex flex-col items-center justify-center gap-4 min-h-[40vh]">
+        <Store size={40} className="text-muted-foreground" />
+        <p className="font-pixel text-[9px] text-center text-muted-foreground">
+          Connectez-vous pour accéder au Marché des héros.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="font-pixel text-[11px] flex items-center gap-2">
+          <Store size={16} /> Marché
+        </h2>
+        <button
+          onClick={() => { refetchListings(); refetchMy(); }}
+          className="pixel-btn pixel-btn-secondary font-pixel text-[7px] flex items-center gap-1 px-2 py-1 min-h-0"
+        >
+          <RefreshCw size={10} /> Actualiser
+        </button>
+      </div>
+
+      {/* Onglets */}
+      <div className="flex gap-1 sticky top-0 bg-background/95 backdrop-blur py-2 z-10">
+        {(['browse', 'my'] as Tab[]).map((t) => (
+          <button
+            key={t}
+            onClick={() => setTab(t)}
+            className={cn(
+              'flex-1 font-pixel text-[8px] py-2 rounded transition-colors',
+              tab === t ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground',
+            )}
+          >
+            {t === 'browse' ? 'Parcourir' : 'Mes annonces'}
+          </button>
+        ))}
+      </div>
+
+      {/* Onglet Parcourir */}
+      {tab === 'browse' && (
+        <div className="space-y-3">
+          {/* Filtres rareté */}
+          <div className="flex gap-1 flex-wrap">
+            <button
+              onClick={() => setFilters((f) => ({ ...f, rarity: undefined }))}
+              className={cn(
+                'font-pixel text-[7px] px-2 py-1 pixel-border transition-colors',
+                !filters.rarity ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground',
+              )}
+            >
+              Tous
+            </button>
+            {SELLABLE_RARITIES.map((r) => (
+              <button
+                key={r}
+                onClick={() => setFilters((f) => ({ ...f, rarity: f.rarity === r ? undefined : r }))}
+                className={cn(
+                  'font-pixel text-[7px] px-2 py-1 pixel-border transition-colors',
+                  filters.rarity === r ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground',
+                )}
+              >
+                {RARITY_CONFIG[r].label}
+              </button>
+            ))}
+          </div>
+
+          {/* Tri */}
+          <div className="flex gap-1 flex-wrap">
+            {([
+              ['newest', 'Récents'],
+              ['price_asc', 'Prix ↑'],
+              ['price_desc', 'Prix ↓'],
+            ] as [MarketplaceFilters['sortBy'], string][]).map(([val, label]) => (
+              <button
+                key={val}
+                onClick={() => setFilters((f) => ({ ...f, sortBy: val }))}
+                className={cn(
+                  'font-pixel text-[7px] px-2 py-1 pixel-border transition-colors',
+                  filters.sortBy === val ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground',
+                )}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          {loadingListings ? (
+            <p className="font-pixel text-[8px] text-muted-foreground text-center py-8">Chargement...</p>
+          ) : listings.length === 0 ? (
+            <div className="text-center py-8 space-y-2">
+              <Tag size={32} className="mx-auto text-muted-foreground" />
+              <p className="font-pixel text-[8px] text-muted-foreground">Aucune annonce disponible.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {listings.map((listing) => (
+                <ListingCard
+                  key={listing.id}
+                  listing={listing}
+                  currentUserId={user.id}
+                  playerCoins={player.bomberCoins}
+                  onBuy={handleBuy}
+                  onCancel={handleCancel}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Onglet Mes annonces */}
+      {tab === 'my' && (
+        <div className="space-y-3">
+          <button
+            onClick={() => setCreateOpen(true)}
+            className="w-full pixel-btn font-pixel text-[8px] flex items-center justify-center gap-2 py-2"
+          >
+            <Tag size={12} /> Mettre un héros en vente
+          </button>
+
+          {loadingMy ? (
+            <p className="font-pixel text-[8px] text-muted-foreground text-center py-8">Chargement...</p>
+          ) : myListings.length === 0 ? (
+            <div className="text-center py-8 space-y-2">
+              <Store size={32} className="mx-auto text-muted-foreground" />
+              <p className="font-pixel text-[8px] text-muted-foreground">Vous n'avez aucune annonce.</p>
+            </div>
+          ) : (
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+              {myListings.map((listing) => (
+                <ListingCard
+                  key={listing.id}
+                  listing={listing}
+                  currentUserId={user.id}
+                  playerCoins={player.bomberCoins}
+                  onBuy={handleBuy}
+                  onCancel={handleCancel}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Modals */}
+      <BuyConfirmModal
+        listing={buyTarget}
+        playerCoins={player.bomberCoins}
+        isLoading={buyHero.isPending}
+        onConfirm={handleConfirmBuy}
+        onClose={() => setBuyTarget(null)}
+      />
+
+      <CreateListingModal
+        open={createOpen}
+        heroes={player.heroes}
+        isLoading={createListing.isPending}
+        onConfirm={handleCreateListing}
+        onClose={() => setCreateOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -1,0 +1,168 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { Rarity } from '@/game/types';
+
+export interface MarketplaceHeroSnapshot {
+  name: string;
+  rarity: Rarity;
+  level: number;
+  stars: number;
+  xp: number;
+  stats: Record<string, number>;
+  skills: unknown[];
+  currentStamina: number;
+  maxStamina: number;
+  houseLevel: number;
+  icon: string;
+  family?: string;
+}
+
+export interface MarketplaceListing {
+  id: string;
+  seller_id: string;
+  hero_id: string;
+  hero_snapshot: MarketplaceHeroSnapshot;
+  price: number;
+  status: string;
+  buyer_id: string | null;
+  created_at: string;
+  sold_at: string | null;
+  cancelled_at: string | null;
+}
+
+export interface MarketplaceFilters {
+  rarity?: Rarity;
+  sortBy?: 'price_asc' | 'price_desc' | 'newest';
+}
+
+export function useListings(filters?: MarketplaceFilters) {
+  return useQuery({
+    queryKey: ['marketplace', 'listings', filters],
+    queryFn: async () => {
+      let query = supabase
+        .from('marketplace_listings')
+        .select('*')
+        .eq('status', 'active');
+
+      const { data, error } = await query.order('created_at', { ascending: false });
+
+      if (error) throw error;
+
+      let listings = (data || []) as MarketplaceListing[];
+
+      // Filtre rareté côté client (hero_snapshot est JSONB)
+      if (filters?.rarity) {
+        listings = listings.filter(
+          (l) => (l.hero_snapshot as MarketplaceHeroSnapshot).rarity === filters.rarity,
+        );
+      }
+
+      // Tri
+      if (filters?.sortBy === 'price_asc') {
+        listings = listings.sort((a, b) => a.price - b.price);
+      } else if (filters?.sortBy === 'price_desc') {
+        listings = listings.sort((a, b) => b.price - a.price);
+      }
+
+      return listings;
+    },
+    staleTime: 30 * 1000, // 30 secondes
+  });
+}
+
+export function useMyListings(userId: string | undefined) {
+  return useQuery({
+    queryKey: ['marketplace', 'myListings', userId],
+    queryFn: async () => {
+      if (!userId) return [];
+      const { data, error } = await supabase
+        .from('marketplace_listings')
+        .select('*')
+        .eq('seller_id', userId)
+        .in('status', ['active', 'sold'])
+        .order('created_at', { ascending: false });
+      if (error) throw error;
+      return (data || []) as MarketplaceListing[];
+    },
+    enabled: !!userId,
+    staleTime: 30 * 1000,
+  });
+}
+
+export function useCreateListing() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      sellerId,
+      heroId,
+      price,
+    }: {
+      sellerId: string;
+      heroId: string;
+      price: number;
+    }) => {
+      const { data, error } = await supabase.rpc('list_hero_for_sale' as never, {
+        p_seller_id: sellerId,
+        p_hero_id: heroId,
+        p_price: price,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string; listing_id?: string };
+      if (!result.success) throw new Error(result.error || 'Erreur lors de la mise en vente.');
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace'] });
+    },
+  });
+}
+
+export function useBuyHero() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      listingId,
+      buyerId,
+    }: {
+      listingId: string;
+      buyerId: string;
+    }) => {
+      const { data, error } = await supabase.rpc('buy_hero' as never, {
+        p_listing_id: listingId,
+        p_buyer_id: buyerId,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string; new_hero_id?: string; price_paid?: number };
+      if (!result.success) throw new Error(result.error || "Erreur lors de l'achat.");
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace'] });
+    },
+  });
+}
+
+export function useCancelListing() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      listingId,
+      sellerId,
+    }: {
+      listingId: string;
+      sellerId: string;
+    }) => {
+      const { data, error } = await supabase.rpc('cancel_listing' as never, {
+        p_listing_id: listingId,
+        p_seller_id: sellerId,
+      });
+      if (error) throw error;
+      const result = data as { success: boolean; error?: string };
+      if (!result.success) throw new Error(result.error || "Erreur lors de l'annulation.");
+      return result;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['marketplace'] });
+    },
+  });
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -14,6 +14,44 @@ export type Database = {
   }
   public: {
     Tables: {
+      marketplace_listings: {
+        Row: {
+          id: string
+          seller_id: string
+          hero_id: string
+          hero_snapshot: Json
+          price: number
+          status: string
+          buyer_id: string | null
+          created_at: string
+          sold_at: string | null
+          cancelled_at: string | null
+        }
+        Insert: {
+          id?: string
+          seller_id: string
+          hero_id: string
+          hero_snapshot: Json
+          price: number
+          status?: string
+          buyer_id?: string | null
+          created_at?: string
+          sold_at?: string | null
+          cancelled_at?: string | null
+        }
+        Update: {
+          id?: string
+          seller_id?: string
+          hero_id?: string
+          hero_snapshot?: Json
+          price?: number
+          status?: string
+          buyer_id?: string | null
+          sold_at?: string | null
+          cancelled_at?: string | null
+        }
+        Relationships: []
+      }
       player_heroes: {
         Row: {
           id: string

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -32,6 +32,7 @@ import { getExplosionTiles } from '@/game/engine';
 import { generateShardRewards, applyShardRewards, ShardReward, generateUniversalShardReward } from '@/game/shardRewardSystem';
 import { recycleHeroes } from '@/game/recycleSystem';
 import RecyclePanel from '@/components/RecyclePanel';
+import MarketplacePage from '@/components/marketplace/MarketplacePage';
 import DailyQuests from '@/components/DailyQuests';
 import Achievements from '@/components/Achievements';
 import PlayerStats from '@/components/PlayerStats';
@@ -53,7 +54,7 @@ import DailyResetTimer from '@/components/DailyResetTimer';
 import { SFX, isMuted, setMuted } from '@/game/sfx';
 import { toast } from 'sonner';
 
-type Screen = 'hub' | 'treasure-hunt' | 'heroes' | 'codex' | 'fusion' | 'summon' | 'story' | 'story-battle' | 'achievements' | 'combat' | 'recycle';
+type Screen = 'hub' | 'treasure-hunt' | 'heroes' | 'codex' | 'fusion' | 'summon' | 'story' | 'story-battle' | 'achievements' | 'combat' | 'recycle' | 'marketplace';
 
 
 
@@ -204,6 +205,7 @@ const Index = () => {
   const {
     canWriteCloud,
     isCloudLoading,
+    loadFromCloud,
     saveHeroesToCloud,
     removeHeroesFromCloud,
     saveStatsToCloud,
@@ -1255,18 +1257,18 @@ const Index = () => {
         onToggleMute={toggleMute}
       />
 
-      {/* Container swipeable 5 pages */}
+      {/* Container swipeable 6 pages */}
       <motion.div
         className="flex flex-1 min-h-0 pt-12"
-        style={{ width: '500%' }}
-        animate={{ x: `${-page * 20}%` }}
+        style={{ width: '600%' }}
+        animate={{ x: `${-page * (100 / 6)}%` }}
         transition={{ type: 'spring', stiffness: 300, damping: 30 }}
         onTouchStart={handleTouchStart}
         onTouchEnd={handleTouchEnd}
       >
 
         {/* PAGE 0 — Invoquer */}
-        <div className="w-1/5 h-full overflow-y-auto pb-nav md:pl-16">
+        <div className="w-1/6 h-full overflow-y-auto pb-nav md:pl-16">
           <div className="p-4 max-w-2xl mx-auto space-y-4">
             {/* Tabs BC / Shards */}
             <div className="flex gap-2">
@@ -1436,7 +1438,7 @@ const Index = () => {
         </div>
 
         {/* PAGE 1 — Héros */}
-        <div className="w-1/5 h-full overflow-y-auto pb-nav md:pl-16">
+        <div className="w-1/6 h-full overflow-y-auto pb-nav md:pl-16">
           <div className="p-4 max-w-6xl mx-auto">
             {upgradeHeroId && upgradeHeroData ? (
               /* VUE DÉTAIL HÉROS — pleine page */
@@ -1739,7 +1741,7 @@ const Index = () => {
         </div>
 
         {/* PAGE 2 — Combat */}
-        <div className={`w-1/5 h-full overflow-y-auto pb-nav ${isInBattle ? '' : 'md:pl-16'}`}>
+        <div className={`w-1/6 h-full overflow-y-auto pb-nav ${isInBattle ? '' : 'md:pl-16'}`}>
           <div className="p-4 max-w-6xl mx-auto">
             {/* Tabs Chasse au Trésor / Mode Histoire */}
             {!isInBattle && (
@@ -2234,7 +2236,7 @@ const Index = () => {
         </div>
 
         {/* PAGE 3 — Social */}
-        <div className="w-1/5 h-full overflow-y-auto pb-nav md:pl-16">
+        <div className="w-1/6 h-full overflow-y-auto pb-nav md:pl-16">
           <div className="p-4 max-w-2xl mx-auto space-y-6">
             {/* Player Stats */}
             <PlayerStats
@@ -2317,7 +2319,7 @@ const Index = () => {
         </div>
 
         {/* PAGE 4 — Forge */}
-        <div className="w-1/5 h-full overflow-y-auto pb-nav md:pl-16">
+        <div className="w-1/6 h-full overflow-y-auto pb-nav md:pl-16">
           <div className="p-4 max-w-2xl mx-auto">
             {/* Sub-tabs Fusion | Recyclage */}
             <div className="flex gap-1 mb-4 sticky top-0 bg-background/95 backdrop-blur py-2 z-10">
@@ -2547,6 +2549,24 @@ const Index = () => {
               </motion.div>
             )}
           </div>
+        </div>
+
+        {/* PAGE 5 — Marché */}
+        <div className="w-1/6 h-full overflow-y-auto pb-nav md:pl-16">
+          <MarketplacePage
+            player={player}
+            user={user}
+            onTransactionComplete={async () => {
+              if (user && loadFromCloud) {
+                const data = await loadFromCloud();
+                if (data) {
+                  setPlayer(data.playerData);
+                  setStoryProgress(data.storyProgress);
+                  setDailyQuests(data.dailyQuests);
+                }
+              }
+            }}
+          />
         </div>
 
       </motion.div>

--- a/supabase/migrations/20260321120000_add_marketplace.sql
+++ b/supabase/migrations/20260321120000_add_marketplace.sql
@@ -1,0 +1,152 @@
+-- Marketplace listings
+CREATE TABLE public.marketplace_listings (
+  id            UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  seller_id     UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  hero_id       TEXT        NOT NULL,
+  hero_snapshot JSONB       NOT NULL,
+  price         BIGINT      NOT NULL CHECK (price >= 100 AND price <= 999999999),
+  status        TEXT        NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'sold', 'cancelled')),
+  buyer_id      UUID        REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  sold_at       TIMESTAMPTZ,
+  cancelled_at  TIMESTAMPTZ
+);
+
+ALTER TABLE public.marketplace_listings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "authenticated can view active listings"
+  ON public.marketplace_listings FOR SELECT
+  USING (auth.uid() IS NOT NULL AND (status = 'active' OR seller_id = auth.uid() OR buyer_id = auth.uid()));
+
+CREATE POLICY "seller can insert own listings"
+  ON public.marketplace_listings FOR INSERT
+  WITH CHECK (auth.uid() = seller_id);
+
+CREATE POLICY "seller can update own listings"
+  ON public.marketplace_listings FOR UPDATE
+  USING (auth.uid() = seller_id AND status = 'active');
+
+CREATE INDEX idx_marketplace_status ON public.marketplace_listings(status) WHERE status = 'active';
+CREATE INDEX idx_marketplace_seller ON public.marketplace_listings(seller_id);
+CREATE INDEX idx_marketplace_created ON public.marketplace_listings(created_at DESC) WHERE status = 'active';
+
+-- RPC buy_hero : transaction atomique
+CREATE OR REPLACE FUNCTION buy_hero(p_listing_id UUID, p_buyer_id UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_listing  marketplace_listings%ROWTYPE;
+  v_price    BIGINT;
+  v_hero     JSONB;
+  v_buyer_coins BIGINT;
+  v_new_hero_id TEXT;
+BEGIN
+  SELECT * INTO v_listing FROM marketplace_listings
+  WHERE id = p_listing_id AND status = 'active' FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Listing introuvable ou déjà vendu.');
+  END IF;
+  IF v_listing.seller_id = p_buyer_id THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Vous ne pouvez pas acheter votre propre héros.');
+  END IF;
+  v_price := v_listing.price;
+  v_hero  := v_listing.hero_snapshot;
+  SELECT (save_data->>'bomberCoins')::BIGINT INTO v_buyer_coins
+  FROM player_saves WHERE user_id = p_buyer_id FOR UPDATE;
+  IF v_buyer_coins IS NULL OR v_buyer_coins < v_price THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Fonds insuffisants.');
+  END IF;
+  UPDATE player_saves
+  SET save_data = jsonb_set(save_data, '{bomberCoins}', to_jsonb(v_buyer_coins - v_price))
+  WHERE user_id = p_buyer_id;
+  UPDATE player_saves
+  SET save_data = jsonb_set(save_data, '{bomberCoins}', to_jsonb((save_data->>'bomberCoins')::BIGINT + (v_price * 95 / 100)))
+  WHERE user_id = v_listing.seller_id;
+  v_new_hero_id := 'hero_' || extract(epoch from now())::BIGINT::TEXT || '_' || floor(random()*10000)::TEXT;
+  INSERT INTO player_heroes (id, user_id, name, rarity, level, stars, stats, skills,
+    current_stamina, max_stamina, is_active, house_level, icon, xp, is_locked, family)
+  VALUES (
+    v_new_hero_id, p_buyer_id,
+    v_hero->>'name', v_hero->>'rarity',
+    (v_hero->>'level')::INTEGER, (v_hero->>'stars')::INTEGER,
+    v_hero->'stats', v_hero->'skills',
+    (v_hero->>'currentStamina')::NUMERIC, (v_hero->>'maxStamina')::NUMERIC,
+    false, (v_hero->>'houseLevel')::INTEGER, v_hero->>'icon',
+    COALESCE((v_hero->>'xp')::INTEGER, 0), false, v_hero->>'family'
+  );
+  DELETE FROM player_heroes WHERE id = v_listing.hero_id AND user_id = v_listing.seller_id;
+  UPDATE marketplace_listings
+  SET status = 'sold', buyer_id = p_buyer_id, sold_at = now()
+  WHERE id = p_listing_id;
+  RETURN jsonb_build_object('success', true, 'new_hero_id', v_new_hero_id, 'price_paid', v_price);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION buy_hero TO authenticated;
+
+-- RPC list_hero_for_sale
+CREATE OR REPLACE FUNCTION list_hero_for_sale(p_seller_id UUID, p_hero_id TEXT, p_price BIGINT)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_hero    player_heroes%ROWTYPE;
+  v_snapshot JSONB;
+  v_listing_id UUID;
+BEGIN
+  SELECT * INTO v_hero FROM player_heroes WHERE id = p_hero_id AND user_id = p_seller_id FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Héros introuvable.');
+  END IF;
+  IF v_hero.rarity NOT IN ('epic', 'legend', 'super-legend') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Seuls les héros Epic, Legend et Super-Legend peuvent être vendus.');
+  END IF;
+  IF COALESCE(v_hero.is_locked, false) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ce héros est verrouillé.');
+  END IF;
+  IF EXISTS (SELECT 1 FROM marketplace_listings WHERE hero_id = p_hero_id AND seller_id = p_seller_id AND status = 'active') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ce héros est déjà en vente.');
+  END IF;
+  v_snapshot := jsonb_build_object(
+    'name', v_hero.name, 'rarity', v_hero.rarity, 'level', v_hero.level,
+    'stars', v_hero.stars, 'xp', v_hero.xp, 'stats', v_hero.stats,
+    'skills', v_hero.skills, 'currentStamina', v_hero.current_stamina,
+    'maxStamina', v_hero.max_stamina, 'houseLevel', v_hero.house_level,
+    'icon', v_hero.icon, 'family', v_hero.family
+  );
+  INSERT INTO marketplace_listings (seller_id, hero_id, hero_snapshot, price)
+  VALUES (p_seller_id, p_hero_id, v_snapshot, p_price) RETURNING id INTO v_listing_id;
+  DELETE FROM player_heroes WHERE id = p_hero_id AND user_id = p_seller_id;
+  RETURN jsonb_build_object('success', true, 'listing_id', v_listing_id);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION list_hero_for_sale TO authenticated;
+
+-- RPC cancel_listing
+CREATE OR REPLACE FUNCTION cancel_listing(p_listing_id UUID, p_seller_id UUID)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_listing marketplace_listings%ROWTYPE;
+  v_hero    JSONB;
+BEGIN
+  SELECT * INTO v_listing FROM marketplace_listings
+  WHERE id = p_listing_id AND seller_id = p_seller_id AND status = 'active' FOR UPDATE;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Listing introuvable.');
+  END IF;
+  v_hero := v_listing.hero_snapshot;
+  INSERT INTO player_heroes (id, user_id, name, rarity, level, stars, stats, skills,
+    current_stamina, max_stamina, is_active, house_level, icon, xp, is_locked, family)
+  VALUES (
+    v_listing.hero_id, p_seller_id,
+    v_hero->>'name', v_hero->>'rarity',
+    (v_hero->>'level')::INTEGER, (v_hero->>'stars')::INTEGER,
+    v_hero->'stats', v_hero->'skills',
+    (v_hero->>'currentStamina')::NUMERIC, (v_hero->>'maxStamina')::NUMERIC,
+    false, (v_hero->>'houseLevel')::INTEGER, v_hero->>'icon',
+    COALESCE((v_hero->>'xp')::INTEGER, 0), false, v_hero->>'family'
+  );
+  UPDATE marketplace_listings SET status = 'cancelled', cancelled_at = now() WHERE id = p_listing_id;
+  RETURN jsonb_build_object('success', true);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION cancel_listing TO authenticated;


### PR DESCRIPTION
## Résumé

Implémente la marketplace joueur-à-joueur (issue #11) : vente de héros Epic/Legend/Super-Legend contre des BomberCoins.

## Changements

### Backend (Supabase)
- Migration `20260321120000_add_marketplace.sql` : table `marketplace_listings` + RLS policies
- RPC `list_hero_for_sale` : retire le héros du roster et crée un listing (atomique)
- RPC `buy_hero` : transaction atomique (débit acheteur, crédit vendeur 95%, transfert héros)
- RPC `cancel_listing` : remet le héros dans le roster du vendeur

### Frontend
- `src/hooks/useMarketplace.ts` : hooks TanStack (useListings, useMyListings, useCreateListing, useBuyHero, useCancelListing)
- `src/components/marketplace/ListingCard.tsx` : card de listing avec hero preview + prix
- `src/components/marketplace/CreateListingModal.tsx` : modal mise en vente
- `src/components/marketplace/BuyConfirmModal.tsx` : confirmation achat avec solde
- `src/components/marketplace/MarketplacePage.tsx` : page complète (browse + mes annonces)
- `src/components/MainNav.tsx` : 6ème onglet "Marché" (icone Store)
- `src/pages/Index.tsx` : intégration PAGE 5 + Screen 'marketplace' + reload cloud post-transaction

## Règles métier
- Seuls les héros Epic, Legend et Super-Legend peuvent être vendus
- Héros verrouillés non vendables
- Le héros est retiré du roster pendant la mise en vente (anti-exploit)
- Taxe de 5% côté vendeur
- Transaction atomique via RPC côté serveur

## Test plan
- [ ] `npm run build` — zéro erreur TypeScript
- [ ] Mise en vente : sélectionner héros epic+, fixer prix, confirmer
- [ ] Achat : parcourir listings, confirmer achat, vérifier transfert
- [ ] Annulation : listing retiré, héros retourné dans le roster
- [ ] Filtres rareté + tri fonctionnels
- [ ] Rechargement cloud automatique après transaction

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)