### PR TITLE
fix: marketplace accessible + bouton fin histoire mobile

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1208,7 +1208,7 @@ const Index = () => {
 
   const isInBattle = screen === 'treasure-hunt' || screen === 'story-battle';
 
-  const PAGE_TITLES = ['Invoquer', 'Héros', 'Combat', 'Social', 'Forge'];
+  const PAGE_TITLES = ['Invoquer', 'Héros', 'Combat', 'Social', 'Forge', 'Marché'];
 
   // Touch swipe handlers
   const touchStartX = useRef(0);
@@ -1223,7 +1223,7 @@ const Index = () => {
     const deltaX = e.changedTouches[0].clientX - touchStartX.current;
     const deltaY = e.changedTouches[0].clientY - touchStartY.current;
     if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > 60) {
-      if (deltaX < 0) setPage(p => Math.min(4, p + 1));
+      if (deltaX < 0) setPage(p => Math.min(5, p + 1));
       if (deltaX > 0) setPage(p => Math.max(0, p - 1));
     }
   }, []);
@@ -2184,18 +2184,6 @@ const Index = () => {
                 )}
                 </AnimatePresence>
 
-                {/* Defeat Overlay */}
-                {gameState && (
-                  <DefeatOverlay
-                    show={gameState.isStoryMode && gameState.storyFailed}
-                    heroesKO={gameState.heroes.filter(h => h.currentStamina === 0)}
-                    onRetry={() => {
-                      if (currentStoryStage) startStoryStage(currentStoryStage);
-                    }}
-                    onQuit={endStoryBattle}
-                  />
-                )}
-
                 {/* Grid */}
                 <div className="flex justify-center flex-col items-center">
                   <GameGrid gameState={gameState} />
@@ -2220,18 +2208,6 @@ const Index = () => {
               </motion.div>
             )}
 
-            {/* Victory Overlay */}
-            {gameState && (
-              <VictoryOverlay
-                show={gameState.mapCompleted && !autoFarm}
-                coinsEarned={gameState.coinsEarned + (currentStoryStage?.reward || 0)}
-                shardsEarned={lastShardRewards.reduce((sum, r) => sum + r.quantity, 0)}
-                chestsOpened={gameState.chestsOpened}
-                heroesActive={selectedHeroes.size}
-                onContinue={gameState.isStoryMode ? endStoryBattle : endTreasureHunt}
-                onAutoFarm={!gameState?.isStoryMode ? () => { setAutoFarm(true); collectAndContinue(true); } : undefined}
-              />
-            )}
           </div>
         </div>
 
@@ -2570,6 +2546,29 @@ const Index = () => {
         </div>
 
       </motion.div>
+
+      {/* Victory & Defeat overlays — placés hors du motion.div pour éviter le clipping par transform */}
+      {gameState && (
+        <VictoryOverlay
+          show={gameState.mapCompleted && !autoFarm}
+          coinsEarned={gameState.coinsEarned + (currentStoryStage?.reward || 0)}
+          shardsEarned={lastShardRewards.reduce((sum, r) => sum + r.quantity, 0)}
+          chestsOpened={gameState.chestsOpened}
+          heroesActive={selectedHeroes.size}
+          onContinue={gameState.isStoryMode ? endStoryBattle : endTreasureHunt}
+          onAutoFarm={!gameState?.isStoryMode ? () => { setAutoFarm(true); collectAndContinue(true); } : undefined}
+        />
+      )}
+      {gameState && (
+        <DefeatOverlay
+          show={gameState.isStoryMode && gameState.storyFailed}
+          heroesKO={gameState.heroes.filter(h => h.currentStamina === 0)}
+          onRetry={() => {
+            if (currentStoryStage) startStoryStage(currentStoryStage);
+          }}
+          onQuit={endStoryBattle}
+        />
+      )}
 
       {!isInBattle && <MainNav page={page} onNavigate={setPage} />}
 


### PR DESCRIPTION
## Bugs corrigés

### BUG 1 — Marketplace inaccessible
- `Math.min(4, p + 1)` → `Math.min(5, p + 1)` dans le handler de swipe pour permettre d'atteindre la page index 5 (6 pages au total)
- Ajout de `'Marché'` comme 6ème entrée dans `PAGE_TITLES`

### BUG 2 — Bouton fin de partie coupé sur mobile en mode Histoire
**Root cause :** `VictoryOverlay` et `DefeatOverlay` étaient rendus à l'intérieur du `motion.div` principal (le swiper). Framer Motion applique un `transform: translateX()` sur ce conteneur pour animer les pages, ce qui crée un nouveau contexte de positionnement CSS. Tout élément `position: fixed` à l'intérieur est alors positionné et clippé relativement à ce conteneur transformé, et non à la viewport — rendant les overlays partiellement recouverts par la MainNav.

**Fix :** Les deux overlays sont déplacés juste après la fermeture du `</motion.div>`, au même niveau que `MainNav` et `TutorialOverlay`. Leurs classes `fixed inset-0 z-50` fonctionnent désormais correctement par rapport à la viewport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)