### PR TITLE
fix: upgradeSystem — SKILL_UNLOCK_LEVELS cohérent + doublons par templateId

### DIFF
--- a/src/game/upgradeSystem.ts
+++ b/src/game/upgradeSystem.ts
@@ -127,7 +127,7 @@ const XP_FOR_LEVEL: Record<number, number> = {
 
 /** Skill unlock levels (every 20 levels) */
 const SKILL_UNLOCK_LEVELS: Record<Rarity, number[]> = {
-  common: [20],
+  common: [],
   rare: [20, 40],
   'super-rare': [20, 40, 60],
   epic: [20, 40, 60, 80],
@@ -452,9 +452,8 @@ export function canUpgradeSkill(
   }
 
   const needed = SKILL_UPGRADE_COST[currentLevel] || 1;
-  const heroBaseName = hero.name.split(' #')[0];
   const availableDuplicates = duplicates.filter(
-    d => d.id !== hero.id && d.name.split(' #')[0] === heroBaseName && !d.isLocked
+    d => d.id !== hero.id && d.templateId && d.templateId === hero.templateId && !d.isLocked
   ).length;
 
   if (availableDuplicates < needed) {
@@ -506,10 +505,9 @@ export function upgradeSkillWithDuplicate(
     return { updatedHeroes: heroes, success: false, message: check.reason, removedIds: [] };
   }
 
-  // Trouver les doublons à consommer (même nom de base, non verrouillés)
-  const heroBaseName = hero.name.split(' #')[0];
+  // Trouver les doublons à consommer (même templateId, non verrouillés)
   const duplicatesToConsume = heroes
-    .filter(d => d.id !== heroId && d.name.split(' #')[0] === heroBaseName && !d.isLocked)
+    .filter(d => d.id !== heroId && d.templateId && d.templateId === hero.templateId && !d.isLocked)
     .slice(0, check.duplicatesNeeded);
 
   const removedIds = duplicatesToConsume.map(d => d.id);

--- a/src/test/skillUpgrade.test.ts
+++ b/src/test/skillUpgrade.test.ts
@@ -6,6 +6,7 @@ import { Hero, Rarity, Skill } from '../game/types';
 function makeHero(id: string, name: string, rarity: Rarity, skills: Skill[] = []): Hero {
   return {
     id,
+    templateId: name, // même templateId pour les doublons d'un même héros
     name: `${name} #${id}`,
     rarity,
     level: 1,


### PR DESCRIPTION
## Fixes

- **#357** `SKILL_UNLOCK_LEVELS.common` : `[20]` → `[]` — cohérent avec `RARITY_CONFIG.common.skills = 0`
- **#367** Identification des doublons : `name.split(' #')[0]` → `hero.templateId` — plus robuste

## Changements

- `upgradeSystem.ts` : `SKILL_UNLOCK_LEVELS.common = []` (était `[20]`)
- `upgradeSystem.ts` : `canUpgradeSkill()` et `upgradeSkillWithDuplicate()` utilisent `templateId` au lieu de `name.split()`
- `skillUpgrade.test.ts` : ajout de `templateId` dans les fixtures `makeHero()` pour refléter la nouvelle logique

🤖 Generated with [Claude Code](https://claude.com/claude-code)