### PR TITLE
fix: quick fixes M11/M12 — templateId, const, catch, hook dep

### DIFF
--- a/src/components/FusionHeroPickerModal.tsx
+++ b/src/components/FusionHeroPickerModal.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useCallback } from 'react';
 import {
   Dialog,
   DialogContent,
@@ -38,7 +38,7 @@ const FusionHeroPickerModal: React.FC<FusionHeroPickerModalProps> = ({
   const requiredRarityConfig = RARITY_CONFIG[requiredRarity as keyof typeof RARITY_CONFIG];
   const maxLevel = requiredRarityConfig?.maxLevel ?? 20;
 
-  const getEligibility = (hero: Hero): HeroEligibility => {
+  const getEligibility = useCallback((hero: Hero): HeroEligibility => {
     if (alreadySelectedIds.includes(hero.id)) {
       return { hero, isEligible: false, reason: 'Déjà assigné' };
     }
@@ -49,7 +49,7 @@ const FusionHeroPickerModal: React.FC<FusionHeroPickerModalProps> = ({
       return { hero, isEligible: false, reason: `Niveau ${maxLevel} requis (${hero.level}/${maxLevel})` };
     }
     return { hero, isEligible: true, reason: '' };
-  };
+  }, [alreadySelectedIds, requiredRarity, maxLevel]);
 
   const { eligibleHeroes, ineligibleHeroes, sortedHeroes } = useMemo(() => {
     const eligible: Hero[] = [], ineligible: Hero[] = [];
@@ -57,7 +57,7 @@ const FusionHeroPickerModal: React.FC<FusionHeroPickerModalProps> = ({
       (getEligibility(h).isEligible ? eligible : ineligible).push(h);
     }
     return { eligibleHeroes: eligible, ineligibleHeroes: ineligible, sortedHeroes: [...eligible, ...ineligible] };
-  }, [heroes, requiredRarity, alreadySelectedIds]);
+  }, [heroes, getEligibility]);
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -445,9 +445,9 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
   if (!state.isRunning || state.isPaused || state.mapCompleted) return state;
 
   const dt = (deltaMs / 1000) * state.speed;
-  let newState = { ...state };
-  let map = { ...newState.map, tiles: newState.map.tiles.map(row => [...row]), chests: [...newState.map.chests] };
-  let heroes = newState.heroes.map(h => ({ ...h, position: { ...h.position } }));
+  const newState = { ...state };
+  const map = { ...newState.map, tiles: newState.map.tiles.map(row => [...row]), chests: [...newState.map.chests] };
+  const heroes = newState.heroes.map(h => ({ ...h, position: { ...h.position } }));
   // Pré-calculer les clan skills une seule fois par tick (#271)
   const activeClanSkills = getActiveClanSkills(heroes);
   let bombs = [...newState.bombs];

--- a/src/game/heroPool.ts
+++ b/src/game/heroPool.ts
@@ -28,7 +28,7 @@ export const HERO_POOL: HeroTemplate[] = [
   { templateId: 'rex',   name: 'Rex',   icon: 'sword',  family: 'forge-guard' },
   { templateId: 'atlas', name: 'Atlas', icon: 'shield', family: 'forge-guard' },
   { templateId: 'duke',  name: 'Duke',  icon: 'crown',  family: 'forge-guard' },
-  { templateId: 'maxg',  name: 'Max',   icon: 'axe',    family: 'forge-guard' },
+  { templateId: 'max',   name: 'Max',   icon: 'axe',    family: 'forge-guard' },
   { templateId: 'brick', name: 'Brick', icon: 'shield', family: 'forge-guard' },
   // shadow-core (ombre)
   { templateId: 'ash',   name: 'Ash',   icon: 'skull',   family: 'shadow-core' },

--- a/src/game/questSystem.ts
+++ b/src/game/questSystem.ts
@@ -178,7 +178,9 @@ export function loadDailyQuests(): DailyQuestData {
       const data: DailyQuestData = JSON.parse(saved);
       if (data.date === getTodayString()) return data;
     }
-  } catch {}
+  } catch (err) {
+    if (import.meta.env.DEV) console.error('[questSystem] Failed to load quests from storage:', err);
+  }
   return generateDailyQuests();
 }
 


### PR DESCRIPTION
## Fixes

- **#353** `heroPool.ts` : `templateId: 'maxg'` → `'max'` — cohérence avec HERO_FAMILY_MAP et HERO_VISUALS
- **#361** `engine.ts` : `let newState/map/heroes` → `const` (jamais réassignés)
- **#362** `questSystem.ts` : `catch {}` vide → log DEV-only
- **#360** `FusionHeroPickerModal.tsx` : `getEligibility` wrappée avec `useCallback`, ajoutée dans les deps du `useMemo`

## Validation

- Build `npm run build` : ✓ aucune erreur (4.11s)
- Lint : aucun nouveau warning introduit par ces changements

🤖 Generated with [Claude Code](https://claude.com/claude-code)