### PR TITLE
feat(gameplay): M13 — chain_chance arcane-circuit, affinité ennemis, coffres crystal/legendary

### DIFF
--- a/src/game/enemyAI.ts
+++ b/src/game/enemyAI.ts
@@ -1,5 +1,7 @@
-import { GameMap } from './types';
+import { GameMap, Bomb, HeroFamilyId } from './types';
 import { Enemy, Boss, ENEMY_CONFIG, BOSS_CONFIG, BossType, EnemyType } from './storyTypes';
+import { getExplosionTiles, findPath } from './engine';
+import { getClanAffinityMultiplier } from './clanSystem';
 
 let enemyIdCounter = 1000;
 const genEnemyId = () => `enemy_${enemyIdCounter++}`;
@@ -305,7 +307,8 @@ export function damageEnemiesFromExplosion(
   enemies: Enemy[],
   explosionTiles: { x: number; y: number }[],
   power: number,
-  heroId?: string
+  heroId?: string,
+  heroFamily?: HeroFamilyId
 ): { enemies: Enemy[]; kills: number; totalDamage: number } {
   let kills = 0;
   let totalDamage = 0;
@@ -313,9 +316,11 @@ export function damageEnemiesFromExplosion(
     const ex = Math.round(e.position.x);
     const ey = Math.round(e.position.y);
     if (explosionTiles.some(t => t.x === ex && t.y === ey)) {
-      const damage = Math.min(e.hp, power);
+      const affinityMult = getClanAffinityMultiplier(heroFamily, e.type);
+      const effectivePower = Math.round(power * affinityMult);
+      const damage = Math.min(e.hp, effectivePower);
       totalDamage += damage;
-      const ne = { ...e, hp: e.hp - power, stunTimer: STUN_DURATION };
+      const ne = { ...e, hp: e.hp - effectivePower, stunTimer: STUN_DURATION };
       if (ne.hp <= 0) kills++;
       return ne;
     }

--- a/src/game/engine.ts
+++ b/src/game/engine.ts
@@ -22,10 +22,10 @@ function buildStoryTargets(
   state: Pick<GameState, 'enemies' | 'boss' | 'isStoryMode'>
 ): { position: { x: number; y: number }; hp: number; isBoss?: boolean }[] | undefined {
   if (!state.isStoryMode) return state.enemies;
-  if (state.boss && state.boss.hp > 0) {
+  if (state.boss && (state.boss as any).hp > 0) {
     return [
       ...(state.enemies || []).map(e => ({ ...e, isBoss: false as const })),
-      { ...state.boss, isBoss: true as const },
+      { ...(state.boss as any), isBoss: true as const },
     ];
   }
   return state.enemies;
@@ -39,7 +39,7 @@ const XP_REWARDS = {
 };
 
 
-export function generateMap(width: number, height: number, blockDensity: number, numChests: number): GameMap {
+export function generateMap(width: number, height: number, blockDensity: number, numChests: number, mapIndex?: number): GameMap {
   const tiles: TileType[][] = [];
 
   for (let y = 0; y < height; y++) {
@@ -89,7 +89,16 @@ export function generateMap(width: number, height: number, blockDensity: number,
   }
 
   const chestCount = Math.min(numChests, floorTiles.length);
-  const tiers: ChestTier[] = ['wood', 'wood', 'wood', 'silver', 'silver', 'gold'];
+  let tiers: ChestTier[];
+  if (mapIndex === undefined || mapIndex <= 1) {
+    tiers = ['wood', 'wood', 'wood', 'silver', 'silver', 'gold'];
+  } else if (mapIndex <= 3) {
+    tiers = ['wood', 'silver', 'silver', 'gold', 'gold'];
+  } else if (mapIndex === 4) {
+    tiers = ['silver', 'gold', 'gold', 'crystal'];
+  } else {
+    tiers = ['gold', 'crystal', 'crystal', 'legendary'];
+  }
 
   for (let i = 0; i < chestCount; i++) {
     const pos = floorTiles[i];
@@ -445,9 +454,9 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
   if (!state.isRunning || state.isPaused || state.mapCompleted) return state;
 
   const dt = (deltaMs / 1000) * state.speed;
-  const newState = { ...state };
-  const map = { ...newState.map, tiles: newState.map.tiles.map(row => [...row]), chests: [...newState.map.chests] };
-  const heroes = newState.heroes.map(h => ({ ...h, position: { ...h.position } }));
+  let newState = { ...state };
+  let map = { ...newState.map, tiles: newState.map.tiles.map(row => [...row]), chests: [...newState.map.chests] };
+  let heroes = newState.heroes.map(h => ({ ...h, position: { ...h.position } }));
   // Pré-calculer les clan skills une seule fois par tick (#271)
   const activeClanSkills = getActiveClanSkills(heroes);
   let bombs = [...newState.bombs];
@@ -526,11 +535,14 @@ export function tickGame(state: GameState, deltaMs: number): GameState {
     const chainedBombs = bombs.filter(b =>
       tiles.some(t => t.x === b.position.x && t.y === b.position.y)
     );
+    const baseChainChance = 0.80;
+    const chainChanceBonus = getClanBonus('chain_chance', heroes, activeClanSkills);
+    const chainChance = Math.min(1.0, baseChainChance + chainChanceBonus);
     for (const cb of chainedBombs) {
+      if (Math.random() >= chainChance) continue;
       bombs = bombs.filter(b => b.id !== cb.id);
       const cbTiles = getExplosionTiles(map, cb.position, cb.range);
       explosions.push({ id: genId(), tiles: cbTiles, timer: 0.4, team: cb.team, heroId: cb.heroId, family: cb.family });
-      // TODO #168 chain_chance arcane-circuit : augmenter la probabilité de réaction en chaîne si cb.family === 'arcane-circuit'
     }
 
     // Explosion damage to heroes: only enemy bombs can hurt heroes

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,8 +24,8 @@ import { loadPlayerData, savePlayerData, getDefaultPlayerData, saveStoryProgress
 import { getUpgradeCost, upgradeHero, ascendHero, getAscensionCost, countDuplicates, upgradeSkillWithDuplicate } from '@/game/upgradeSystem';
 import { trackCombatVictory, trackLevelUp, trackChestsOpened, trackBossDefeated, claimAchievementReward, AchievementDefinition, ACHIEVEMENTS } from '@/game/achievements';
 import { DailyQuestData, loadDailyQuests, saveDailyQuests, generateDailyQuests, updateQuestProgress, ALL_CLAIMED_BONUS, ALL_CLAIMED_XP_BONUS } from '@/game/questSystem';
-import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BossType, EnemyType } from '@/game/storyTypes';
-import { getHeroFamily, getClanAffinityMultiplier, getActiveClanSkills } from '@/game/clanSystem';
+import { StoryProgress, StoryStage, BOSS_LEVEL_BY_TYPE, BossType } from '@/game/storyTypes';
+import { getHeroFamily, getActiveClanSkills } from '@/game/clanSystem';
 import { spawnEnemy, spawnBoss, tickEnemies, tickBoss, damageEnemiesFromExplosion, damageBossFromExplosion, checkEnemyHeroCollision, checkBossHeroCollision } from '@/game/enemyAI';
 import { STORY_REGIONS } from '@/game/storyData';
 import { getExplosionTiles } from '@/game/engine';
@@ -453,22 +453,11 @@ const Index = () => {
             processedExplosionsRef.current.add(exp.id);
             SFX.explosion();
             if (exp.team === 'heroes') {
-              // Trouver le héros ayant posé la bombe pour appliquer son affinité clan (#154)
-              // TODO #154 : affinité précise par ennemi individuel — nécessite refacto damageEnemiesFromExplosion
+              // Trouver le héros ayant posé la bombe pour appliquer son affinité clan par ennemi individuel (#154, #366)
               const bombHero = exp.heroId ? state.heroes.find(h => h.id === exp.heroId) : undefined;
               const heroFamily = bombHero ? getHeroFamily(bombHero) : undefined;
-              // Calculer un multiplicateur d'affinité moyen basé sur les types d'ennemis présents dans l'explosion
-              const hitEnemies = enemies.filter(e => {
-                const ex = Math.round(e.position.x);
-                const ey = Math.round(e.position.y);
-                return e.hp > 0 && exp.tiles.some(t => t.x === ex && t.y === ey);
-              });
-              const affinityMult = hitEnemies.length > 0
-                ? hitEnemies.reduce((sum, e) => sum + getClanAffinityMultiplier(heroFamily, e.type as EnemyType), 0) / hitEnemies.length
-                : 1.0;
               const basePower = Math.max(...state.heroes.map(h => h.stats.pwr), 1);
-              const heroPower = Math.round(basePower * affinityMult);
-              const { enemies: updatedEnemies, kills, totalDamage } = damageEnemiesFromExplosion(enemies, exp.tiles, heroPower, exp.heroId);
+              const { enemies: updatedEnemies, kills, totalDamage } = damageEnemiesFromExplosion(enemies, exp.tiles, basePower, exp.heroId, heroFamily);
               enemies = updatedEnemies;
               enemiesKilled += kills;
               if (kills > 0) {
@@ -491,7 +480,7 @@ const Index = () => {
 
               if (boss && boss.hp > 0) {
                 const prevHp = boss.hp;
-                const bossResult = damageBossFromExplosion(boss, exp.tiles, heroPower + 1);
+                const bossResult = damageBossFromExplosion(boss, exp.tiles, basePower + 1);
                 boss = bossResult.boss;
                 if (boss.hp < prevHp) {
                   SFX.bossHit();
@@ -613,7 +602,7 @@ const Index = () => {
 
   const startTreasureHunt = () => {
     const mapConfig = MAP_CONFIGS[selectedMap];
-    const map = generateMap(mapConfig.width, mapConfig.height, mapConfig.blockDensity, mapConfig.chests);
+    const map = generateMap(mapConfig.width, mapConfig.height, mapConfig.blockDensity, mapConfig.chests, selectedMap);
 
     const spawnPoints = [
       { x: 1, y: 1 }, { x: map.width - 2, y: 1 },


### PR DESCRIPTION
## Résumé

Implémentation des 3 features gameplay du milestone M13.

- **#365 — `chain_chance` arcane-circuit** : la réaction en chaîne n'est plus garantie à 100%. La probabilité de base est de 80% et le clan Arcane-Circuit (skill `chain_chance: +0.20`) la porte à 100%. Utilise `getClanBonus('chain_chance', heroes, activeClanSkills)` dans `engine.ts`.

- **#366 — Affinité de dégâts par ennemi individuel** : `damageEnemiesFromExplosion()` dans `enemyAI.ts` accepte désormais un paramètre `heroFamily?: HeroFamilyId` et applique `getClanAffinityMultiplier()` pour chaque ennemi touché individuellement. `Index.tsx` simplifié : suppression du calcul de multiplicateur moyen.

- **#369 — Coffres `crystal`/`legendary` sur les cartes hauts niveaux** : `generateMap()` accepte un paramètre `mapIndex?: number`. Les tables de tiers varient selon le niveau de la carte (Prairie/Forêt, Mines/Château, Volcan, Citadelle+). `startTreasureHunt()` passe `selectedMap` comme mapIndex.

## Fichiers modifiés

- `src/game/engine.ts` — chain_chance, generateMap avec mapIndex
- `src/game/enemyAI.ts` — damageEnemiesFromExplosion avec heroFamily
- `src/pages/Index.tsx` — appels mis à jour, imports nettoyés

## Tests

- `npm run build` ✅ (exit 0)
- `npm test` ✅ 223 tests passent / 14 suites

Closes #365, #366, #369

🤖 Generated with [Claude Code](https://claude.com/claude-code)