### PR TITLE
fix: marketplace — snapshot héros en fallback RPC (Héros introuvable)

### DIFF
--- a/src/components/marketplace/CreateListingModal.tsx
+++ b/src/components/marketplace/CreateListingModal.tsx
@@ -17,7 +17,7 @@ interface CreateListingModalProps {
   open: boolean;
   heroes: Hero[];
   isLoading: boolean;
-  onConfirm: (heroId: string, price: number) => void;
+  onConfirm: (heroId: string, price: number, hero: Hero) => void;
   onClose: () => void;
 }
 
@@ -38,8 +38,8 @@ export default function CreateListingModal({
   const selectedHero = sellableHeroes.find((h) => h.id === selectedHeroId) ?? null;
 
   const handleConfirm = () => {
-    if (!selectedHeroId || price < 100) return;
-    onConfirm(selectedHeroId, price);
+    if (!selectedHeroId || !selectedHero || price < 100) return;
+    onConfirm(selectedHeroId, price, selectedHero);
     setSelectedHeroId(null);
     setPrice(1000);
   };

--- a/src/components/marketplace/MarketplacePage.tsx
+++ b/src/components/marketplace/MarketplacePage.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Store, Tag, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
-import { PlayerData, Rarity, RARITY_CONFIG } from '@/game/types';
+import { PlayerData, Rarity, RARITY_CONFIG, Hero } from '@/game/types';
 import {
   useListings,
   useMyListings,
@@ -64,10 +64,24 @@ export default function MarketplacePage({ player, user, onTransactionComplete }:
     }
   };
 
-  const handleCreateListing = async (heroId: string, price: number) => {
+  const handleCreateListing = async (heroId: string, price: number, hero: Hero) => {
     if (!user) return;
+    const heroSnapshot = {
+      name: hero.name,
+      rarity: hero.rarity,
+      level: hero.level,
+      stars: hero.stars,
+      xp: hero.xp,
+      stats: hero.stats as Record<string, number>,
+      skills: hero.skills,
+      currentStamina: hero.currentStamina,
+      maxStamina: hero.maxStamina,
+      houseLevel: hero.houseLevel,
+      icon: hero.icon,
+      family: hero.family,
+    };
     try {
-      await createListing.mutateAsync({ sellerId: user.id, heroId, price });
+      await createListing.mutateAsync({ sellerId: user.id, heroId, price, heroSnapshot });
       toast.success('Héros mis en vente avec succès !');
       setCreateOpen(false);
       onTransactionComplete();

--- a/src/hooks/useMarketplace.ts
+++ b/src/hooks/useMarketplace.ts
@@ -96,15 +96,18 @@ export function useCreateListing() {
       sellerId,
       heroId,
       price,
+      heroSnapshot,
     }: {
       sellerId: string;
       heroId: string;
       price: number;
+      heroSnapshot?: MarketplaceHeroSnapshot;
     }) => {
       const { data, error } = await supabase.rpc('list_hero_for_sale' as never, {
         p_seller_id: sellerId,
         p_hero_id: heroId,
         p_price: price,
+        p_hero_snapshot: heroSnapshot ?? null,
       } as never);
       if (error) throw error;
       const result = data as { success: boolean; error?: string; listing_id?: string };

--- a/supabase/migrations/20260322180000_fix_marketplace_hero_snapshot.sql
+++ b/supabase/migrations/20260322180000_fix_marketplace_hero_snapshot.sql
@@ -1,0 +1,81 @@
+-- Fix list_hero_for_sale : accepte un hero_snapshot en fallback
+-- si le héros n'est pas encore dans player_heroes (sync cloud non effectué)
+CREATE OR REPLACE FUNCTION list_hero_for_sale(
+  p_seller_id     UUID,
+  p_hero_id       TEXT,
+  p_price         BIGINT,
+  p_hero_snapshot JSONB DEFAULT NULL
+)
+RETURNS JSONB LANGUAGE plpgsql SECURITY DEFINER SET search_path = public
+AS $$
+DECLARE
+  v_hero      player_heroes%ROWTYPE;
+  v_snapshot  JSONB;
+  v_rarity    TEXT;
+  v_listing_id UUID;
+BEGIN
+  -- Chercher le héros dans player_heroes (version cloud-synced)
+  SELECT * INTO v_hero
+  FROM player_heroes
+  WHERE id = p_hero_id AND user_id = p_seller_id
+  FOR UPDATE;
+
+  IF FOUND THEN
+    -- Héros trouvé en DB : on utilise les données serveur (plus sûr)
+    v_rarity   := v_hero.rarity;
+    v_snapshot := jsonb_build_object(
+      'name',           v_hero.name,
+      'rarity',         v_hero.rarity,
+      'level',          v_hero.level,
+      'stars',          v_hero.stars,
+      'xp',             v_hero.xp,
+      'stats',          v_hero.stats,
+      'skills',         v_hero.skills,
+      'currentStamina', v_hero.current_stamina,
+      'maxStamina',     v_hero.max_stamina,
+      'houseLevel',     v_hero.house_level,
+      'icon',           v_hero.icon,
+      'family',         v_hero.family
+    );
+    IF COALESCE(v_hero.is_locked, false) THEN
+      RETURN jsonb_build_object('success', false, 'error', 'Ce héros est verrouillé.');
+    END IF;
+  ELSIF p_hero_snapshot IS NOT NULL THEN
+    -- Fallback : héros pas encore synchronisé dans la DB, on utilise le snapshot client
+    v_rarity   := p_hero_snapshot->>'rarity';
+    v_snapshot := p_hero_snapshot;
+  ELSE
+    RETURN jsonb_build_object('success', false, 'error', 'Héros introuvable. Synchronisez votre compte et réessayez.');
+  END IF;
+
+  -- Validation rareté
+  IF v_rarity NOT IN ('epic', 'legend', 'super-legend') THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Seuls les héros Épique, Légendaire et Super-Légendaire peuvent être vendus.');
+  END IF;
+
+  -- Validation prix
+  IF p_price < 100 OR p_price > 999999999 THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Prix invalide (100 – 999 999 999 coins).');
+  END IF;
+
+  -- Déjà en vente ?
+  IF EXISTS (
+    SELECT 1 FROM marketplace_listings
+    WHERE hero_id = p_hero_id AND seller_id = p_seller_id AND status = 'active'
+  ) THEN
+    RETURN jsonb_build_object('success', false, 'error', 'Ce héros est déjà en vente.');
+  END IF;
+
+  -- Créer l'annonce
+  INSERT INTO marketplace_listings (seller_id, hero_id, hero_snapshot, price)
+  VALUES (p_seller_id, p_hero_id, v_snapshot, p_price)
+  RETURNING id INTO v_listing_id;
+
+  -- Retirer le héros de player_heroes s'il y était
+  DELETE FROM player_heroes WHERE id = p_hero_id AND user_id = p_seller_id;
+
+  RETURN jsonb_build_object('success', true, 'listing_id', v_listing_id);
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION list_hero_for_sale TO authenticated;


### PR DESCRIPTION
## Root cause

`list_hero_for_sale` cherchait le héros dans la table `player_heroes` (cloud Supabase), mais les héros peuvent exister uniquement en localStorage si la synchronisation cloud n'a pas encore eu lieu.

→ RPC retournait `{ success: false, error: 'Héros introuvable.' }` à chaque tentative de mise en vente.

## Fix

### SQL (nouvelle migration `20260322180000_fix_marketplace_hero_snapshot.sql`)
`list_hero_for_sale` accepte maintenant un 4ème paramètre optionnel `p_hero_snapshot JSONB DEFAULT NULL` :
- Si le héros est dans `player_heroes` → utilise les données DB (sécurisé)
- Sinon si `p_hero_snapshot` fourni → utilise le snapshot client (fallback)
- Sinon → erreur explicite "Héros introuvable. Synchronisez votre compte."

### Frontend
- `useCreateListing` accepte `heroSnapshot?: MarketplaceHeroSnapshot`
- `MarketplacePage` construit le snapshot depuis l'objet Hero local et le passe au hook
- `CreateListingModal.onConfirm` retourne maintenant `(heroId, price, hero)` au lieu de `(heroId, price)`

## ⚠️ Action requise : appliquer la migration Supabase

```bash
! supabase login
! supabase link --project-ref yowgyfruqfdbzymwakgk
! supabase db push
```

Ou coller le SQL de `supabase/migrations/20260322180000_fix_marketplace_hero_snapshot.sql` directement dans le SQL Editor Supabase.

## Test plan
- [x] `npm run build` ✓
- [ ] Mettre un héros Epic/Legend en vente → doit réussir sans erreur
- [ ] Annuler une annonce → héros doit réapparaître dans la collection
- [ ] Acheter un héros → doit déduire les coins correctement

🤖 Generated with [Claude Code](https://claude.com/claude-code)